### PR TITLE
First-Divergence Diffing

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -116,19 +116,23 @@ The goal is to establish a **trustworthy core**, not a feature-rich platform.
 
 ---
 
-### v0.3 — Diffing
+### v0.3 — First-divergence diffing ✅
 - Step-by-step comparison of two runs
-- Detection of first divergence
-- Clear presentation of old vs new state
+- Detection of first divergence with resync window
+- Deterministic canonicalization (NFC unicode, sorted keys, stable floats)
+- Structured JSON diff patches (add/remove/replace with stable ordering)
+- Seven divergence types: exact_match, input/output/op/error divergence, missing/extra steps
+- Clear presentation of old vs new state with context window
+- JSON-serializable `FirstDivergenceResult`
 
 ---
 
-### v0.4 — Minimal CLI
+### v0.4 — Minimal CLI (in progress)
+- `forkline diff --first` ✅
 - `forkline run`
 - `forkline replay`
-- `forkline diff`
-- Human-readable output
-- Scriptable exit codes
+- Human-readable text output and JSON output ✅
+- Scriptable exit codes ✅
 
 ---
 

--- a/forkline/__init__.py
+++ b/forkline/__init__.py
@@ -1,21 +1,21 @@
 from .core import (
+    # First-divergence diffing
+    DivergenceType,
     # Core types
     Event,
+    FirstDivergenceResult,
     # Redaction
     RedactionAction,
     RedactionRule,
     Run,
     Step,
+    StepSummary,
+    # Canonicalization
+    canon,
     create_default_policy,
     # Diff
     diff_runs,
-    # First-divergence diffing
-    DivergenceType,
-    FirstDivergenceResult,
-    StepSummary,
     find_first_divergence,
-    # Canonicalization
-    canon,
     json_diff,
     sha256_hex,
 )

--- a/forkline/__init__.py
+++ b/forkline/__init__.py
@@ -9,6 +9,15 @@ from .core import (
     create_default_policy,
     # Diff
     diff_runs,
+    # First-divergence diffing
+    DivergenceType,
+    FirstDivergenceResult,
+    StepSummary,
+    find_first_divergence,
+    # Canonicalization
+    canon,
+    json_diff,
+    sha256_hex,
 )
 from .core.redaction import RedactionPolicy
 from .core.replay import (
@@ -65,8 +74,17 @@ __all__ = [
     "Tracer",
     "SQLiteStore",
     "RunRecorder",
+    # Canonicalization
+    "canon",
+    "sha256_hex",
+    "json_diff",
     # Diff
     "diff_runs",
+    # First-divergence diffing
+    "find_first_divergence",
+    "FirstDivergenceResult",
+    "StepSummary",
+    "DivergenceType",
     # Redaction
     "RedactionAction",
     "RedactionPolicy",

--- a/forkline/cli.py
+++ b/forkline/cli.py
@@ -6,6 +6,7 @@ Usage:
     forkline diff --first <run_a> <run_b> [--window N] [--format json|text]
                   [--show input|output|both] [--canon strict] [--db PATH]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -72,9 +73,7 @@ def _format_text(result) -> str:
         for op in result.input_diff[:10]:
             lines.append(f"    {op['op']} {op['path']}: {_compact_value(op)}")
         if len(result.input_diff) > 10:
-            lines.append(
-                f"    ... and {len(result.input_diff) - 10} more operations"
-            )
+            lines.append(f"    ... and {len(result.input_diff) - 10} more operations")
         lines.append("")
 
     if result.output_diff:
@@ -82,9 +81,7 @@ def _format_text(result) -> str:
         for op in result.output_diff[:10]:
             lines.append(f"    {op['op']} {op['path']}: {_compact_value(op)}")
         if len(result.output_diff) > 10:
-            lines.append(
-                f"    ... and {len(result.output_diff) - 10} more operations"
-            )
+            lines.append(f"    ... and {len(result.output_diff) - 10} more operations")
         lines.append("")
 
     lines.append(f"  Last equal: step {result.last_equal_idx}")

--- a/forkline/cli.py
+++ b/forkline/cli.py
@@ -16,7 +16,6 @@ import sys
 from .core.first_divergence import DivergenceType, find_first_divergence
 from .storage.store import SQLiteStore
 
-
 # ---------------------------------------------------------------------------
 # Text formatter
 # ---------------------------------------------------------------------------

--- a/forkline/cli.py
+++ b/forkline/cli.py
@@ -1,0 +1,194 @@
+"""Forkline CLI.
+
+Entry point for the ``forkline`` command-line tool.
+
+Usage:
+    forkline diff --first <run_a> <run_b> [--window N] [--format json|text]
+                  [--show input|output|both] [--canon strict] [--db PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .core.first_divergence import DivergenceType, find_first_divergence
+from .storage.store import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Text formatter
+# ---------------------------------------------------------------------------
+
+
+def _compact_value(op: dict) -> str:
+    if op["op"] == "replace":
+        old = json.dumps(op.get("old"), default=str)
+        new = json.dumps(op.get("new"), default=str)
+        if len(old) > 40:
+            old = old[:37] + "..."
+        if len(new) > 40:
+            new = new[:37] + "..."
+        return f"{old} -> {new}"
+    if op["op"] == "add":
+        val = json.dumps(op.get("value"), default=str)
+        if len(val) > 40:
+            val = val[:37] + "..."
+        return val
+    if op["op"] == "remove":
+        val = json.dumps(op.get("old"), default=str)
+        if len(val) > 40:
+            val = val[:37] + "..."
+        return val
+    return ""
+
+
+def _format_text(result) -> str:
+    lines: list[str] = []
+    lines.append(f"First divergence: {result.status}")
+    lines.append(f"  {result.explanation}")
+    lines.append("")
+
+    if result.old_step:
+        s = result.old_step
+        lines.append(f"  Run A step {s.idx} '{s.name}':")
+        lines.append(f"    input_hash:  {s.input_hash[:16]}...")
+        lines.append(f"    output_hash: {s.output_hash[:16]}...")
+        lines.append(f"    events: {s.event_count}")
+        lines.append(f"    has_error: {s.has_error}")
+        lines.append("")
+
+    if result.new_step:
+        s = result.new_step
+        lines.append(f"  Run B step {s.idx} '{s.name}':")
+        lines.append(f"    input_hash:  {s.input_hash[:16]}...")
+        lines.append(f"    output_hash: {s.output_hash[:16]}...")
+        lines.append(f"    events: {s.event_count}")
+        lines.append(f"    has_error: {s.has_error}")
+        lines.append("")
+
+    if result.input_diff:
+        lines.append("  Input diff:")
+        for op in result.input_diff[:10]:
+            lines.append(f"    {op['op']} {op['path']}: {_compact_value(op)}")
+        if len(result.input_diff) > 10:
+            lines.append(
+                f"    ... and {len(result.input_diff) - 10} more operations"
+            )
+        lines.append("")
+
+    if result.output_diff:
+        lines.append("  Output diff:")
+        for op in result.output_diff[:10]:
+            lines.append(f"    {op['op']} {op['path']}: {_compact_value(op)}")
+        if len(result.output_diff) > 10:
+            lines.append(
+                f"    ... and {len(result.output_diff) - 10} more operations"
+            )
+        lines.append("")
+
+    lines.append(f"  Last equal: step {result.last_equal_idx}")
+
+    if result.context_a:
+        ctx = ", ".join(f"step {s.idx} '{s.name}'" for s in result.context_a)
+        lines.append(f"  Context A: [{ctx}]")
+    if result.context_b:
+        ctx = ", ".join(f"step {s.idx} '{s.name}'" for s in result.context_b)
+        lines.append(f"  Context B: [{ctx}]")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def _cmd_diff(args: argparse.Namespace) -> None:
+    store = SQLiteStore(path=args.db)
+
+    run_a = store.load_run(args.run_a)
+    if run_a is None:
+        print(f"Error: run '{args.run_a}' not found in {args.db}", file=sys.stderr)
+        sys.exit(1)
+
+    run_b = store.load_run(args.run_b)
+    if run_b is None:
+        print(f"Error: run '{args.run_b}' not found in {args.db}", file=sys.stderr)
+        sys.exit(1)
+
+    result = find_first_divergence(
+        run_a,
+        run_b,
+        window=args.window,
+        show=args.show,
+    )
+
+    if args.format == "json":
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+    else:
+        print(_format_text(result))
+
+    if result.status != DivergenceType.EXACT_MATCH:
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="forkline",
+        description="Forkline: replay-first tracing and diffing for agentic workflows",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    diff_parser = subparsers.add_parser("diff", help="Compare two recorded runs")
+    diff_parser.add_argument(
+        "--first",
+        action="store_true",
+        default=True,
+        help="Show first divergence only (default)",
+    )
+    diff_parser.add_argument("run_a", help="Run ID for baseline")
+    diff_parser.add_argument("run_b", help="Run ID for comparison")
+    diff_parser.add_argument(
+        "--window", type=int, default=10, help="Resync window size (default: 10)"
+    )
+    diff_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    diff_parser.add_argument(
+        "--show",
+        choices=["input", "output", "both"],
+        default="both",
+        help="Which diffs to show (default: both)",
+    )
+    diff_parser.add_argument(
+        "--canon",
+        choices=["strict"],
+        default="strict",
+        help="Canonicalization profile (default: strict)",
+    )
+    diff_parser.add_argument(
+        "--db",
+        default="forkline.db",
+        help="Path to SQLite database (default: forkline.db)",
+    )
+    diff_parser.set_defaults(func=_cmd_diff)
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/forkline/core/__init__.py
+++ b/forkline/core/__init__.py
@@ -1,6 +1,14 @@
 """Core types and logic for Forkline."""
 
+from .canon import bytes_preview, canon, sha256_hex
 from .diff import diff_runs
+from .first_divergence import (
+    DivergenceType,
+    FirstDivergenceResult,
+    StepSummary,
+    find_first_divergence,
+)
+from .json_diff import json_diff
 from .redaction import (
     RedactionAction,
     RedactionPolicy,
@@ -44,8 +52,18 @@ __all__ = [
     "Event",
     "Run",
     "Step",
+    # Canonicalization
+    "canon",
+    "sha256_hex",
+    "bytes_preview",
     # Diff
     "diff_runs",
+    # First-divergence diffing
+    "find_first_divergence",
+    "FirstDivergenceResult",
+    "StepSummary",
+    "DivergenceType",
+    "json_diff",
     # Redaction
     "RedactionAction",
     "RedactionPolicy",

--- a/forkline/core/canon.py
+++ b/forkline/core/canon.py
@@ -11,6 +11,7 @@ Guarantees:
 - Floats use repr-level precision; -0.0 collapses to 0.0
 - Bytes pass through unchanged
 """
+
 from __future__ import annotations
 
 import hashlib

--- a/forkline/core/canon.py
+++ b/forkline/core/canon.py
@@ -1,0 +1,94 @@
+"""Deterministic canonicalization for Forkline values.
+
+Provides stable byte representations and cryptographic hashes for
+deterministic comparison of run data.
+
+Guarantees:
+- canon(v) is deterministic: same input always yields identical bytes
+- Dict key order is irrelevant (sorted internally)
+- Unicode is NFC-normalized
+- Newlines are normalized to LF
+- Floats use repr-level precision; -0.0 collapses to 0.0
+- Bytes pass through unchanged
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import unicodedata
+from typing import Any
+
+
+def canon(value: Any, profile: str = "strict") -> bytes:
+    """Canonicalize a value to bytes for deterministic comparison.
+
+    Args:
+        value: bytes (returned as-is), str (NFC + newline normalized, UTF-8),
+               or JSON-like (sorted keys, stable floats, compact JSON, UTF-8).
+        profile: Canonicalization profile. Currently only "strict".
+
+    Returns:
+        Canonical byte representation.
+    """
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return _canon_str(value).encode("utf-8")
+    return _canon_json(value).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    """Compute SHA-256 hex digest of bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def bytes_preview(data: bytes, max_len: int = 16) -> str:
+    """Human-readable preview: sha256 hash + hex prefix."""
+    prefix = data[:max_len].hex()
+    return f"sha256:{sha256_hex(data)}:{prefix}"
+
+
+def _canon_str(s: str) -> str:
+    s = unicodedata.normalize("NFC", s)
+    s = s.replace("\r\n", "\n").replace("\r", "\n")
+    return s
+
+
+def _canon_json(value: Any) -> str:
+    return json.dumps(
+        _normalize_value(value),
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _normalize_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "Infinity" if value > 0 else "-Infinity"
+        normalized = float(f"{value:.17g}")
+        if normalized == 0.0:
+            normalized = 0.0
+        return normalized
+    if isinstance(value, str):
+        return _canon_str(value)
+    if isinstance(value, bytes):
+        return {"__bytes__": True, "sha256": sha256_hex(value), "length": len(value)}
+    if isinstance(value, dict):
+        return {
+            str(k): _normalize_value(v)
+            for k, v in sorted(value.items(), key=lambda x: str(x[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(v) for v in value]
+    return str(value)

--- a/forkline/core/first_divergence.py
+++ b/forkline/core/first_divergence.py
@@ -11,6 +11,7 @@ Algorithm:
 4. If resync fails, classify by what differs: op > input > error > output.
 5. Return structured result with context, diffs, and deterministic explanation.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -124,9 +125,7 @@ def _make_summary(step: Step) -> StepSummary:
     )
 
 
-def _get_context(
-    steps: List[Step], center: int, size: int = 2
-) -> List[StepSummary]:
+def _get_context(steps: List[Step], center: int, size: int = 2) -> List[StepSummary]:
     start = max(0, center - size)
     end = min(len(steps), center + size + 1)
     return [_make_summary(steps[i]) for i in range(start, end)]
@@ -365,9 +364,7 @@ def find_first_divergence(
             # Both gaps > 0: steps were replaced — fall through to classify
 
         # No resync or replacement — classify at current position
-        input_diff, output_diff = _compute_diffs(
-            steps_a[i], steps_b[i], dtype, show
-        )
+        input_diff, output_diff = _compute_diffs(steps_a[i], steps_b[i], dtype, show)
         return FirstDivergenceResult(
             status=dtype,
             idx_a=i,
@@ -405,9 +402,7 @@ def find_first_divergence(
             last_equal_idx=last_equal,
             context_a=_get_context(steps_a, idx, context_size),
             context_b=(
-                _get_context(steps_b, len(steps_b) - 1, context_size)
-                if steps_b
-                else []
+                _get_context(steps_b, len(steps_b) - 1, context_size) if steps_b else []
             ),
         )
 
@@ -432,9 +427,7 @@ def find_first_divergence(
             output_diff=None,
             last_equal_idx=last_equal,
             context_a=(
-                _get_context(steps_a, len(steps_a) - 1, context_size)
-                if steps_a
-                else []
+                _get_context(steps_a, len(steps_a) - 1, context_size) if steps_a else []
             ),
             context_b=_get_context(steps_b, idx, context_size),
         )

--- a/forkline/core/first_divergence.py
+++ b/forkline/core/first_divergence.py
@@ -14,12 +14,12 @@ Algorithm:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from .canon import canon, sha256_hex
 from .json_diff import json_diff
-from .types import Event, Run, Step
+from .types import Run, Step
 
 
 class DivergenceType:

--- a/forkline/core/first_divergence.py
+++ b/forkline/core/first_divergence.py
@@ -1,0 +1,455 @@
+"""First-divergence diffing engine for Forkline.
+
+Compares two recorded runs step-by-step and returns the FIRST point of
+divergence with deterministic classification, explanation, and structured diffs.
+
+Algorithm:
+1. Fast-path lockstep comparison until mismatch.
+2. On mismatch, attempt resync within a sliding window using soft signatures
+   (step name + canonicalized input hash).
+3. If resync succeeds, classify as missing_steps or extra_steps.
+4. If resync fails, classify by what differs: op > input > error > output.
+5. Return structured result with context, diffs, and deterministic explanation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from .canon import canon, sha256_hex
+from .json_diff import json_diff
+from .types import Event, Run, Step
+
+
+class DivergenceType:
+    """Classification of the first point of divergence between two runs."""
+
+    EXACT_MATCH = "exact_match"
+    INPUT_DIVERGENCE = "input_divergence"
+    OUTPUT_DIVERGENCE = "output_divergence"
+    OP_DIVERGENCE = "op_divergence"
+    MISSING_STEPS = "missing_steps"
+    EXTRA_STEPS = "extra_steps"
+    ERROR_DIVERGENCE = "error_divergence"
+
+
+@dataclass(frozen=True)
+class StepSummary:
+    """Compact summary of a step for inclusion in diff results."""
+
+    idx: int
+    name: str
+    input_hash: str
+    output_hash: str
+    event_count: int
+    has_error: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "idx": self.idx,
+            "name": self.name,
+            "input_hash": self.input_hash,
+            "output_hash": self.output_hash,
+            "event_count": self.event_count,
+            "has_error": self.has_error,
+        }
+
+
+@dataclass(frozen=True)
+class FirstDivergenceResult:
+    """Result of first-divergence comparison between two runs."""
+
+    status: str
+    idx_a: Optional[int]
+    idx_b: Optional[int]
+    explanation: str
+    old_step: Optional[StepSummary]
+    new_step: Optional[StepSummary]
+    input_diff: Optional[List[Dict[str, Any]]]
+    output_diff: Optional[List[Dict[str, Any]]]
+    last_equal_idx: int
+    context_a: List[StepSummary]
+    context_b: List[StepSummary]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "idx_a": self.idx_a,
+            "idx_b": self.idx_b,
+            "explanation": self.explanation,
+            "last_equal_idx": self.last_equal_idx,
+            "old_step": self.old_step.to_dict() if self.old_step else None,
+            "new_step": self.new_step.to_dict() if self.new_step else None,
+            "input_diff": self.input_diff,
+            "output_diff": self.output_diff,
+            "context_a": [s.to_dict() for s in self.context_a],
+            "context_b": [s.to_dict() for s in self.context_b],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Step helpers
+# ---------------------------------------------------------------------------
+
+
+def _step_events_by_type(step: Step, event_type: str) -> List[Dict[str, Any]]:
+    return [e.payload for e in step.events if e.type == event_type]
+
+
+def _step_input_hash(step: Step) -> str:
+    return sha256_hex(canon(_step_events_by_type(step, "input")))
+
+
+def _step_output_hash(step: Step) -> str:
+    return sha256_hex(canon(_step_events_by_type(step, "output")))
+
+
+def _step_has_error(step: Step) -> bool:
+    return any(e.type == "error" for e in step.events)
+
+
+def _step_signature(step: Step) -> Tuple[str, str]:
+    """Soft signature for resync: (name, input_hash)."""
+    return (step.name, _step_input_hash(step))
+
+
+def _make_summary(step: Step) -> StepSummary:
+    return StepSummary(
+        idx=step.idx,
+        name=step.name,
+        input_hash=_step_input_hash(step),
+        output_hash=_step_output_hash(step),
+        event_count=len(step.events),
+        has_error=_step_has_error(step),
+    )
+
+
+def _get_context(
+    steps: List[Step], center: int, size: int = 2
+) -> List[StepSummary]:
+    start = max(0, center - size)
+    end = min(len(steps), center + size + 1)
+    return [_make_summary(steps[i]) for i in range(start, end)]
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_step_divergence(step_a: Step, step_b: Step) -> str:
+    if step_a.name != step_b.name:
+        return DivergenceType.OP_DIVERGENCE
+
+    if _step_input_hash(step_a) != _step_input_hash(step_b):
+        return DivergenceType.INPUT_DIVERGENCE
+
+    has_err_a = _step_has_error(step_a)
+    has_err_b = _step_has_error(step_b)
+    if has_err_a != has_err_b:
+        return DivergenceType.ERROR_DIVERGENCE
+    if has_err_a and has_err_b:
+        errors_a = _step_events_by_type(step_a, "error")
+        errors_b = _step_events_by_type(step_b, "error")
+        if canon(errors_a) != canon(errors_b):
+            return DivergenceType.ERROR_DIVERGENCE
+
+    if _step_output_hash(step_a) != _step_output_hash(step_b):
+        return DivergenceType.OUTPUT_DIVERGENCE
+
+    # Fallback: compare all events (catches tool_call, artifact_ref, etc.)
+    all_a = [(e.type, e.payload) for e in step_a.events]
+    all_b = [(e.type, e.payload) for e in step_b.events]
+    if canon(all_a) != canon(all_b):
+        return DivergenceType.OUTPUT_DIVERGENCE
+
+    return DivergenceType.EXACT_MATCH
+
+
+# ---------------------------------------------------------------------------
+# Resync
+# ---------------------------------------------------------------------------
+
+
+def _try_resync(
+    steps_a: List[Step],
+    steps_b: List[Step],
+    start: int,
+    window: int,
+) -> Optional[Tuple[int, int]]:
+    """Find earliest matching signature pair within the resync window.
+
+    Iterates by increasing combined distance from *start* so that the
+    closest resync point is found first. Ties broken by smaller offset_a.
+    """
+    for total_dist in range(1, 2 * window + 1):
+        for offset_a in range(min(total_dist + 1, window)):
+            offset_b = total_dist - offset_a
+            if offset_b < 0 or offset_b >= window:
+                continue
+            ia = start + offset_a
+            ib = start + offset_b
+            if ia >= len(steps_a) or ib >= len(steps_b):
+                continue
+            if _step_signature(steps_a[ia]) == _step_signature(steps_b[ib]):
+                return (ia, ib)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Explanation
+# ---------------------------------------------------------------------------
+
+
+def _make_explanation(
+    dtype: str,
+    step_a: Optional[Step],
+    step_b: Optional[Step],
+    idx_a: Optional[int],
+    idx_b: Optional[int],
+    gap_a: int = 0,
+    gap_b: int = 0,
+) -> str:
+    if dtype == DivergenceType.EXACT_MATCH:
+        return "Runs are identical"
+
+    if dtype == DivergenceType.OP_DIVERGENCE:
+        name_a = step_a.name if step_a else "?"
+        name_b = step_b.name if step_b else "?"
+        return f"Step {idx_a}: operation mismatch ('{name_a}' vs '{name_b}')"
+
+    if dtype == DivergenceType.INPUT_DIVERGENCE:
+        name = step_a.name if step_a else "?"
+        return f"Step {idx_a} '{name}': input differs"
+
+    if dtype == DivergenceType.OUTPUT_DIVERGENCE:
+        name = step_a.name if step_a else "?"
+        return f"Step {idx_a} '{name}': output differs (same input)"
+
+    if dtype == DivergenceType.ERROR_DIVERGENCE:
+        name = step_a.name if step_a else "?"
+        return f"Step {idx_a} '{name}': error state differs"
+
+    if dtype == DivergenceType.MISSING_STEPS:
+        if gap_a > 1:
+            end_idx = idx_a + gap_a - 1
+            return f"Steps {idx_a}..{end_idx} from run_a missing in run_b"
+        return f"Step {idx_a} from run_a missing in run_b"
+
+    if dtype == DivergenceType.EXTRA_STEPS:
+        if gap_b > 1:
+            end_idx = idx_b + gap_b - 1
+            return f"Steps {idx_b}..{end_idx} in run_b not present in run_a"
+        return f"Step {idx_b} in run_b not present in run_a"
+
+    return f"Unknown divergence at indices ({idx_a}, {idx_b})"
+
+
+# ---------------------------------------------------------------------------
+# Diff computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_diffs(
+    step_a: Optional[Step],
+    step_b: Optional[Step],
+    dtype: str,
+    show: str = "both",
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+    input_diff: Optional[List[Dict[str, Any]]] = None
+    output_diff: Optional[List[Dict[str, Any]]] = None
+
+    if step_a is None or step_b is None:
+        return None, None
+
+    if dtype == DivergenceType.INPUT_DIVERGENCE and show in ("input", "both"):
+        inputs_a = _step_events_by_type(step_a, "input")
+        inputs_b = _step_events_by_type(step_b, "input")
+        input_diff = json_diff(inputs_a, inputs_b)
+
+    if dtype == DivergenceType.OUTPUT_DIVERGENCE and show in ("output", "both"):
+        outputs_a = _step_events_by_type(step_a, "output")
+        outputs_b = _step_events_by_type(step_b, "output")
+        output_diff = json_diff(outputs_a, outputs_b)
+
+    return input_diff, output_diff
+
+
+# ---------------------------------------------------------------------------
+# Main engine
+# ---------------------------------------------------------------------------
+
+
+def find_first_divergence(
+    run_a: Run,
+    run_b: Run,
+    *,
+    window: int = 10,
+    context_size: int = 2,
+    show: str = "both",
+) -> FirstDivergenceResult:
+    """Find the first point of divergence between two runs.
+
+    Args:
+        run_a: The baseline run.
+        run_b: The comparison run.
+        window: Resync window size (default 10).
+        context_size: Steps before/after divergence in context (default 2).
+        show: Which diffs to include: "input", "output", or "both".
+
+    Returns:
+        FirstDivergenceResult with classification, explanation, and diffs.
+    """
+    steps_a = run_a.steps
+    steps_b = run_b.steps
+    last_equal = -1
+
+    i = 0
+    while i < len(steps_a) and i < len(steps_b):
+        dtype = _classify_step_divergence(steps_a[i], steps_b[i])
+        if dtype == DivergenceType.EXACT_MATCH:
+            last_equal = i
+            i += 1
+            continue
+
+        # Mismatch — attempt resync within window
+        resync = _try_resync(steps_a, steps_b, i, window)
+        if resync is not None:
+            ia, ib = resync
+            gap_a = ia - i
+            gap_b = ib - i
+
+            if gap_a > 0 and gap_b == 0:
+                return FirstDivergenceResult(
+                    status=DivergenceType.MISSING_STEPS,
+                    idx_a=i,
+                    idx_b=i,
+                    explanation=_make_explanation(
+                        DivergenceType.MISSING_STEPS,
+                        steps_a[i],
+                        steps_b[i],
+                        i,
+                        i,
+                        gap_a=gap_a,
+                    ),
+                    old_step=_make_summary(steps_a[i]),
+                    new_step=_make_summary(steps_b[i]),
+                    input_diff=None,
+                    output_diff=None,
+                    last_equal_idx=last_equal,
+                    context_a=_get_context(steps_a, i, context_size),
+                    context_b=_get_context(steps_b, i, context_size),
+                )
+
+            if gap_b > 0 and gap_a == 0:
+                return FirstDivergenceResult(
+                    status=DivergenceType.EXTRA_STEPS,
+                    idx_a=i,
+                    idx_b=i,
+                    explanation=_make_explanation(
+                        DivergenceType.EXTRA_STEPS,
+                        steps_a[i],
+                        steps_b[i],
+                        i,
+                        i,
+                        gap_b=gap_b,
+                    ),
+                    old_step=_make_summary(steps_a[i]),
+                    new_step=_make_summary(steps_b[i]),
+                    input_diff=None,
+                    output_diff=None,
+                    last_equal_idx=last_equal,
+                    context_a=_get_context(steps_a, i, context_size),
+                    context_b=_get_context(steps_b, i, context_size),
+                )
+            # Both gaps > 0: steps were replaced — fall through to classify
+
+        # No resync or replacement — classify at current position
+        input_diff, output_diff = _compute_diffs(
+            steps_a[i], steps_b[i], dtype, show
+        )
+        return FirstDivergenceResult(
+            status=dtype,
+            idx_a=i,
+            idx_b=i,
+            explanation=_make_explanation(dtype, steps_a[i], steps_b[i], i, i),
+            old_step=_make_summary(steps_a[i]),
+            new_step=_make_summary(steps_b[i]),
+            input_diff=input_diff,
+            output_diff=output_diff,
+            last_equal_idx=last_equal,
+            context_a=_get_context(steps_a, i, context_size),
+            context_b=_get_context(steps_b, i, context_size),
+        )
+
+    # One run is longer than the other
+    if len(steps_a) > len(steps_b):
+        idx = len(steps_b)
+        gap = len(steps_a) - len(steps_b)
+        return FirstDivergenceResult(
+            status=DivergenceType.MISSING_STEPS,
+            idx_a=idx,
+            idx_b=None,
+            explanation=_make_explanation(
+                DivergenceType.MISSING_STEPS,
+                steps_a[idx],
+                None,
+                idx,
+                None,
+                gap_a=gap,
+            ),
+            old_step=_make_summary(steps_a[idx]),
+            new_step=None,
+            input_diff=None,
+            output_diff=None,
+            last_equal_idx=last_equal,
+            context_a=_get_context(steps_a, idx, context_size),
+            context_b=(
+                _get_context(steps_b, len(steps_b) - 1, context_size)
+                if steps_b
+                else []
+            ),
+        )
+
+    if len(steps_b) > len(steps_a):
+        idx = len(steps_a)
+        gap = len(steps_b) - len(steps_a)
+        return FirstDivergenceResult(
+            status=DivergenceType.EXTRA_STEPS,
+            idx_a=None,
+            idx_b=idx,
+            explanation=_make_explanation(
+                DivergenceType.EXTRA_STEPS,
+                None,
+                steps_b[idx],
+                None,
+                idx,
+                gap_b=gap,
+            ),
+            old_step=None,
+            new_step=_make_summary(steps_b[idx]),
+            input_diff=None,
+            output_diff=None,
+            last_equal_idx=last_equal,
+            context_a=(
+                _get_context(steps_a, len(steps_a) - 1, context_size)
+                if steps_a
+                else []
+            ),
+            context_b=_get_context(steps_b, idx, context_size),
+        )
+
+    # Runs are identical
+    return FirstDivergenceResult(
+        status=DivergenceType.EXACT_MATCH,
+        idx_a=None,
+        idx_b=None,
+        explanation=f"Runs are identical ({len(steps_a)} steps compared)",
+        old_step=None,
+        new_step=None,
+        input_diff=None,
+        output_diff=None,
+        last_equal_idx=last_equal,
+        context_a=[],
+        context_b=[],
+    )

--- a/forkline/core/json_diff.py
+++ b/forkline/core/json_diff.py
@@ -1,0 +1,61 @@
+"""Deterministic JSON diff patch generation for Forkline.
+
+Produces a stable, ordered list of diff operations for JSON-like values.
+
+Ordering guarantees:
+- dict: removed keys (sorted), then added keys (sorted), then common keys (sorted, recursed)
+- list: by index; removes at tail, then adds at tail
+- Type mismatch: replace whole node
+- int vs float treated as compatible numeric type
+
+Output patch format:
+    [{"op":"remove","path":"$.a.b","old":...},
+     {"op":"add","path":"$.x","value":...},
+     {"op":"replace","path":"$.k","old":...,"new":...}]
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def json_diff(old: Any, new: Any, path: str = "$") -> List[Dict[str, Any]]:
+    """Produce a deterministic JSON diff patch between two values."""
+    ops: List[Dict[str, Any]] = []
+
+    if old is None and new is None:
+        return ops
+
+    if type(old) is not type(new):
+        if isinstance(old, (int, float)) and isinstance(new, (int, float)):
+            if old != new:
+                ops.append({"op": "replace", "path": path, "old": old, "new": new})
+            return ops
+        ops.append({"op": "replace", "path": path, "old": old, "new": new})
+        return ops
+
+    if isinstance(old, dict):
+        old_keys = set(old.keys())
+        new_keys = set(new.keys())
+        for k in sorted(old_keys - new_keys):
+            ops.append({"op": "remove", "path": f"{path}.{k}", "old": old[k]})
+        for k in sorted(new_keys - old_keys):
+            ops.append({"op": "add", "path": f"{path}.{k}", "value": new[k]})
+        for k in sorted(old_keys & new_keys):
+            ops.extend(json_diff(old[k], new[k], f"{path}.{k}"))
+        return ops
+
+    if isinstance(old, list):
+        min_len = min(len(old), len(new))
+        for i in range(min_len):
+            ops.extend(json_diff(old[i], new[i], f"{path}[{i}]"))
+        if len(old) > len(new):
+            for i in range(len(new), len(old)):
+                ops.append({"op": "remove", "path": f"{path}[{i}]", "old": old[i]})
+        elif len(new) > len(old):
+            for i in range(len(old), len(new)):
+                ops.append({"op": "add", "path": f"{path}[{i}]", "value": new[i]})
+        return ops
+
+    if old != new:
+        ops.append({"op": "replace", "path": path, "old": old, "new": new})
+    return ops

--- a/forkline/core/json_diff.py
+++ b/forkline/core/json_diff.py
@@ -3,7 +3,7 @@
 Produces a stable, ordered list of diff operations for JSON-like values.
 
 Ordering guarantees:
-- dict: removed keys (sorted), then added keys (sorted), 
+- dict: removed keys (sorted), then added keys (sorted),
 then common keys (sorted, recursed)
 - list: by index; removes at tail, then adds at tail
 - Type mismatch: replace whole node

--- a/forkline/core/json_diff.py
+++ b/forkline/core/json_diff.py
@@ -13,6 +13,7 @@ Output patch format:
      {"op":"add","path":"$.x","value":...},
      {"op":"replace","path":"$.k","old":...,"new":...}]
 """
+
 from __future__ import annotations
 
 from typing import Any, Dict, List

--- a/forkline/core/json_diff.py
+++ b/forkline/core/json_diff.py
@@ -3,7 +3,8 @@
 Produces a stable, ordered list of diff operations for JSON-like values.
 
 Ordering guarantees:
-- dict: removed keys (sorted), then added keys (sorted), then common keys (sorted, recursed)
+- dict: removed keys (sorted), then added keys (sorted), 
+then common keys (sorted, recursed)
 - list: by index; removes at tail, then adds at tail
 - Type mismatch: replace whole node
 - int vs float treated as compatible numeric type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,11 @@ authors = [
   { name = "Forkline Contributors" }
 ]
 
+[project.scripts]
+forkline = "forkline.cli:main"
+
 [tool.setuptools]
-packages = ["forkline"]
+packages = ["forkline", "forkline.core", "forkline.storage", "forkline.tracer"]
 
 [tool.black]
 line-length = 88

--- a/tests/unit/test_first_divergence.py
+++ b/tests/unit/test_first_divergence.py
@@ -1,0 +1,464 @@
+"""Tests for first-divergence diffing: canonicalization, JSON diff, and engine.
+
+All tests are hermetic — no database, no disk I/O, no network calls.
+Run objects are constructed in-memory from frozen dataclasses.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+
+from forkline.core.canon import bytes_preview, canon, sha256_hex
+from forkline.core.first_divergence import (
+    DivergenceType,
+    FirstDivergenceResult,
+    StepSummary,
+    find_first_divergence,
+)
+from forkline.core.json_diff import json_diff
+from forkline.core.types import Event, Run, Step
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _evt(step_idx: int, typ: str, payload: dict, run_id: str = "test") -> Event:
+    return Event(
+        event_id=None,
+        run_id=run_id,
+        step_idx=step_idx,
+        type=typ,
+        created_at="2024-01-01T00:00:00Z",
+        payload=payload,
+    )
+
+
+def _step(idx: int, name: str, events: list[Event] | None = None, run_id: str = "test") -> Step:
+    return Step(
+        step_id=None,
+        run_id=run_id,
+        idx=idx,
+        name=name,
+        started_at="2024-01-01T00:00:00Z",
+        ended_at="2024-01-01T00:00:01Z",
+        events=events or [],
+    )
+
+
+def _step_io(
+    idx: int, name: str, inp: dict, out: dict, run_id: str = "test"
+) -> Step:
+    return _step(
+        idx,
+        name,
+        [_evt(idx, "input", inp, run_id), _evt(idx, "output", out, run_id)],
+        run_id,
+    )
+
+
+def _run(run_id: str, steps: list[Step]) -> Run:
+    return Run(run_id=run_id, created_at="2024-01-01T00:00:00Z", steps=steps)
+
+
+# ============================================================================
+# Canonicalization stability
+# ============================================================================
+
+
+class TestCanonStability(unittest.TestCase):
+    def test_dict_key_order_irrelevant(self):
+        self.assertEqual(canon({"z": 1, "a": 2, "m": 3}), canon({"a": 2, "m": 3, "z": 1}))
+
+    def test_nested_dict_stability(self):
+        a = {"outer": {"b": 2, "a": 1}, "list": [3, 2, 1]}
+        b = {"list": [3, 2, 1], "outer": {"a": 1, "b": 2}}
+        self.assertEqual(canon(a), canon(b))
+
+    def test_unicode_normalization(self):
+        self.assertEqual(canon("caf\u00e9"), canon("cafe\u0301"))
+
+    def test_newline_normalization(self):
+        self.assertEqual(canon("a\r\nb"), canon("a\nb"))
+        self.assertEqual(canon("a\rb"), canon("a\nb"))
+
+    def test_float_stability(self):
+        a = {"val": 1.0000000000000002}
+        self.assertEqual(canon(a), canon(a))
+
+    def test_negative_zero(self):
+        self.assertEqual(canon({"v": -0.0}), canon({"v": 0.0}))
+
+    def test_bytes_passthrough(self):
+        data = b"\x00\x01\x02\x03"
+        self.assertEqual(canon(data), data)
+
+    def test_sha256_deterministic(self):
+        h1 = sha256_hex(b"hello world")
+        h2 = sha256_hex(b"hello world")
+        self.assertEqual(h1, h2)
+        self.assertEqual(len(h1), 64)
+
+    def test_bytes_preview_format(self):
+        preview = bytes_preview(b"hello world")
+        self.assertTrue(preview.startswith("sha256:"))
+
+    def test_repeated_canonicalization_stable(self):
+        value = {"key": [1, 2, {"nested": "value"}], "other": True}
+        results = [canon(value) for _ in range(100)]
+        self.assertEqual(len(set(results)), 1)
+
+    def test_string_in_json_normalized(self):
+        self.assertEqual(canon({"text": "caf\u00e9"}), canon({"text": "cafe\u0301"}))
+
+    def test_empty_structures(self):
+        self.assertEqual(canon({}), canon({}))
+        self.assertEqual(canon([]), canon([]))
+        self.assertNotEqual(canon({}), canon([]))
+
+    def test_none_value(self):
+        self.assertEqual(canon(None), canon(None))
+
+    def test_bool_vs_int_distinct(self):
+        self.assertNotEqual(canon(True), canon(1))
+
+
+# ============================================================================
+# JSON diff patch determinism
+# ============================================================================
+
+
+class TestJsonDiffDeterminism(unittest.TestCase):
+    def test_identical_values_no_diff(self):
+        self.assertEqual(json_diff({"a": 1}, {"a": 1}), [])
+
+    def test_added_key(self):
+        ops = json_diff({"a": 1}, {"a": 1, "b": 2})
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "add")
+        self.assertEqual(ops[0]["path"], "$.b")
+        self.assertEqual(ops[0]["value"], 2)
+
+    def test_removed_key(self):
+        ops = json_diff({"a": 1, "b": 2}, {"a": 1})
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "remove")
+        self.assertEqual(ops[0]["path"], "$.b")
+
+    def test_replaced_value(self):
+        ops = json_diff({"a": 1}, {"a": 2})
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "replace")
+        self.assertEqual(ops[0]["old"], 1)
+        self.assertEqual(ops[0]["new"], 2)
+
+    def test_ordering_remove_before_add_before_common(self):
+        ops = json_diff({"a": 1, "c": 3}, {"b": 2, "c": 4})
+        self.assertEqual(ops[0]["op"], "remove")
+        self.assertEqual(ops[0]["path"], "$.a")
+        self.assertEqual(ops[1]["op"], "add")
+        self.assertEqual(ops[1]["path"], "$.b")
+        self.assertEqual(ops[2]["op"], "replace")
+        self.assertEqual(ops[2]["path"], "$.c")
+
+    def test_nested_diff(self):
+        ops = json_diff({"outer": {"inner": 1}}, {"outer": {"inner": 2}})
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["path"], "$.outer.inner")
+
+    def test_list_same_length(self):
+        ops = json_diff([1, 2, 3], [1, 4, 3])
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["path"], "$[1]")
+
+    def test_list_shorter(self):
+        ops = json_diff([1, 2, 3], [1, 2])
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "remove")
+        self.assertEqual(ops[0]["path"], "$[2]")
+
+    def test_list_longer(self):
+        ops = json_diff([1, 2], [1, 2, 3])
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "add")
+        self.assertEqual(ops[0]["path"], "$[2]")
+
+    def test_type_change(self):
+        ops = json_diff({"a": [1, 2]}, {"a": "string"})
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "replace")
+
+    def test_deterministic_across_runs(self):
+        old = {"z": 1, "a": 2, "m": {"x": [1, 2, 3]}}
+        new = {"a": 3, "m": {"x": [1, 4, 3], "y": True}, "n": 5}
+        results = [json_diff(old, new) for _ in range(100)]
+        for r in results[1:]:
+            self.assertEqual(r, results[0])
+
+    def test_empty_dicts(self):
+        self.assertEqual(json_diff({}, {}), [])
+
+    def test_empty_lists(self):
+        self.assertEqual(json_diff([], []), [])
+
+    def test_none_values(self):
+        self.assertEqual(json_diff(None, None), [])
+
+    def test_int_float_comparison(self):
+        ops = json_diff({"a": 1}, {"a": 1.5})
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0]["op"], "replace")
+
+
+# ============================================================================
+# First-divergence engine
+# ============================================================================
+
+
+class TestFirstDivergenceEngine(unittest.TestCase):
+    def test_identical_runs_exact_match(self):
+        """a) identical runs => status 'exact_match'"""
+        steps = [
+            _step_io(0, "init", {"prompt": "hello"}, {"result": "world"}),
+            _step_io(1, "process", {"data": [1, 2]}, {"sum": 3}),
+            _step_io(2, "finalize", {"ok": True}, {"done": True}),
+        ]
+        result = find_first_divergence(_run("a", steps), _run("b", steps))
+
+        self.assertEqual(result.status, DivergenceType.EXACT_MATCH)
+        self.assertIsNone(result.idx_a)
+        self.assertIsNone(result.idx_b)
+        self.assertIn("identical", result.explanation)
+        self.assertIn("3 steps", result.explanation)
+
+    def test_output_divergence_same_input(self):
+        """b) output divergence same input => output_divergence"""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "generate", {"prompt": "hi"}, {"text": "hello"}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "generate", {"prompt": "hi"}, {"text": "hey"}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.OUTPUT_DIVERGENCE)
+        self.assertEqual(result.idx_a, 1)
+        self.assertEqual(result.idx_b, 1)
+        self.assertIn("output differs", result.explanation)
+        self.assertIsNotNone(result.output_diff)
+        self.assertEqual(result.last_equal_idx, 0)
+
+    def test_inserted_step_extra_steps(self):
+        """c) inserted step in run_b => extra_steps at insertion point"""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "step_one", {"a": 1}, {"b": 2}),
+            _step_io(2, "step_two", {"c": 3}, {"d": 4}),
+            _step_io(3, "finalize", {"ok": True}, {"done": True}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "step_one", {"a": 1}, {"b": 2}),
+            _step_io(2, "extra_step", {"extra": True}, {"extra_out": True}),
+            _step_io(3, "step_two", {"c": 3}, {"d": 4}),
+            _step_io(4, "finalize", {"ok": True}, {"done": True}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.EXTRA_STEPS)
+        self.assertEqual(result.idx_b, 2)
+        self.assertEqual(result.last_equal_idx, 1)
+
+    def test_run_b_shorter_missing_steps(self):
+        """d) run_b shorter => missing_steps"""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "process", {"a": 1}, {"b": 2}),
+            _step_io(2, "finalize", {"ok": True}, {"done": True}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.MISSING_STEPS)
+        self.assertEqual(result.idx_a, 1)
+        self.assertIn("missing", result.explanation)
+        self.assertEqual(result.last_equal_idx, 0)
+
+    def test_op_mismatch_no_resync(self):
+        """e) op mismatch without resync => op_divergence"""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "process_a", {"a": 1}, {"b": 2}),
+            _step_io(2, "cleanup_a", {"c": 3}, {"d": 4}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "process_b", {"e": 5}, {"f": 6}),
+            _step_io(2, "cleanup_b", {"g": 7}, {"h": 8}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.OP_DIVERGENCE)
+        self.assertEqual(result.idx_a, 1)
+        self.assertEqual(result.idx_b, 1)
+        self.assertIn("operation mismatch", result.explanation)
+        self.assertIn("process_a", result.explanation)
+        self.assertIn("process_b", result.explanation)
+
+    def test_empty_runs_match(self):
+        result = find_first_divergence(_run("a", []), _run("b", []))
+        self.assertEqual(result.status, DivergenceType.EXACT_MATCH)
+
+    def test_error_divergence(self):
+        """One step has an error event, the other doesn't."""
+        run_a = _run("a", [
+            _step(0, "process", [
+                _evt(0, "input", {"x": 1}),
+                _evt(0, "output", {"y": 2}),
+            ]),
+        ])
+        run_b = _run("b", [
+            _step(0, "process", [
+                _evt(0, "input", {"x": 1}),
+                _evt(0, "error", {"message": "failed"}),
+            ]),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+        self.assertEqual(result.status, DivergenceType.ERROR_DIVERGENCE)
+
+    def test_input_divergence(self):
+        """Same step name but different input."""
+        run_a = _run("a", [
+            _step_io(0, "process", {"prompt": "hello"}, {"result": "world"}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "process", {"prompt": "goodbye"}, {"result": "world"}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.INPUT_DIVERGENCE)
+        self.assertIsNotNone(result.input_diff)
+
+    def test_result_json_serialization(self):
+        """DiffResult can be serialized to JSON."""
+        run_a = _run("a", [_step_io(0, "init", {"x": 1}, {"y": 2})])
+        run_b = _run("b", [_step_io(0, "init", {"x": 1}, {"y": 3})])
+
+        result = find_first_divergence(run_a, run_b)
+        d = result.to_dict()
+
+        self.assertIsInstance(d, dict)
+        self.assertIn("status", d)
+        self.assertIn("explanation", d)
+        self.assertIn("context_a", d)
+        json_str = json.dumps(d)
+        self.assertIsInstance(json_str, str)
+
+    def test_context_window(self):
+        """Context includes steps before and after divergence."""
+        steps = [
+            _step_io(i, f"step_{i}", {"i": i}, {"o": i}) for i in range(6)
+        ]
+        run_a = _run("a", steps)
+        steps_b = list(steps)
+        steps_b[3] = _step_io(3, "step_3", {"i": 3}, {"o": 999})
+        run_b = _run("b", steps_b)
+
+        result = find_first_divergence(run_a, run_b, context_size=2)
+
+        self.assertEqual(result.status, DivergenceType.OUTPUT_DIVERGENCE)
+        self.assertEqual(result.idx_a, 3)
+        self.assertTrue(len(result.context_a) >= 3)
+
+    def test_deterministic_across_invocations(self):
+        """Same inputs always produce identical results."""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "process", {"data": [1, 2, 3]}, {"sum": 6}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "process", {"data": [1, 2, 3]}, {"sum": 7}),
+        ])
+
+        results = [find_first_divergence(run_a, run_b).to_dict() for _ in range(50)]
+        for r in results[1:]:
+            self.assertEqual(r, results[0])
+
+    def test_run_a_shorter_extra_steps(self):
+        """run_a shorter than run_b => extra_steps in run_b."""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "extra", {"e": 1}, {"e": 2}),
+            _step_io(2, "extra2", {"e": 3}, {"e": 4}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.EXTRA_STEPS)
+        self.assertEqual(result.idx_b, 1)
+        self.assertIn("not present", result.explanation)
+
+    def test_deleted_step_missing_steps_via_resync(self):
+        """Step removed from run_b detected via resync as missing_steps."""
+        run_a = _run("a", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "middle", {"m": 1}, {"m": 2}),
+            _step_io(2, "end", {"z": 9}, {"z": 10}),
+        ])
+        run_b = _run("b", [
+            _step_io(0, "init", {"x": 1}, {"y": 2}),
+            _step_io(1, "end", {"z": 9}, {"z": 10}),
+        ])
+
+        result = find_first_divergence(run_a, run_b)
+
+        self.assertEqual(result.status, DivergenceType.MISSING_STEPS)
+        self.assertEqual(result.idx_a, 1)
+        self.assertEqual(result.last_equal_idx, 0)
+
+    def test_step_summary_fields(self):
+        """StepSummary.to_dict() contains all expected fields."""
+        step = _step_io(5, "my_step", {"k": "v"}, {"out": 42})
+        result = find_first_divergence(
+            _run("a", [step]),
+            _run("b", [_step_io(5, "my_step", {"k": "v"}, {"out": 99})]),
+        )
+        self.assertIsNotNone(result.old_step)
+        d = result.old_step.to_dict()
+        for field in ("idx", "name", "input_hash", "output_hash", "event_count", "has_error"):
+            self.assertIn(field, d)
+
+    def test_show_input_only(self):
+        """show='input' omits output diff even on output divergence."""
+        run_a = _run("a", [_step_io(0, "s", {"i": 1}, {"o": 1})])
+        run_b = _run("b", [_step_io(0, "s", {"i": 1}, {"o": 2})])
+
+        result = find_first_divergence(run_a, run_b, show="input")
+        self.assertIsNone(result.output_diff)
+
+    def test_show_output_only(self):
+        """show='output' omits input diff even on input divergence."""
+        run_a = _run("a", [_step_io(0, "s", {"i": 1}, {"o": 1})])
+        run_b = _run("b", [_step_io(0, "s", {"i": 2}, {"o": 1})])
+
+        result = find_first_divergence(run_a, run_b, show="output")
+        self.assertIsNone(result.input_diff)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_first_divergence.py
+++ b/tests/unit/test_first_divergence.py
@@ -12,13 +12,10 @@ import unittest
 from forkline.core.canon import bytes_preview, canon, sha256_hex
 from forkline.core.first_divergence import (
     DivergenceType,
-    FirstDivergenceResult,
-    StepSummary,
     find_first_divergence,
 )
 from forkline.core.json_diff import json_diff
 from forkline.core.types import Event, Run, Step
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
# Forkline v0.3 Release Notes — First-Divergence Diffing

**Release:** v0.1.2  
**Date:** 2026-02-21  
**Milestone:** v0.1.2 — First-Divergence Diffing (Roadmap item 3 of 5)

---

## Summary

This release delivers **first-divergence diffing**: given two recorded runs, Forkline now compares them step-by-step and returns the **first point of divergence** with deterministic classification, structured JSON diff patches, and rule-based explanations.

This is the core feature that turns Forkline from a recording/replay tool into a **forensic debugging tool** — answering not just *that* two runs differ, but *where*, *how*, and *what changed*.

---

## What's New

### 1. Deterministic Canonicalization (`forkline/core/canon.py`)

A canonicalization layer that produces **stable, deterministic byte representations** of any value before hashing or diffing.

**Functions:**
- `canon(value, profile="strict") -> bytes` — Canonicalize any value to bytes
- `sha256_hex(data: bytes) -> str` — SHA-256 hex digest
- `bytes_preview(data: bytes) -> str` — Human-readable `sha256:<hash>:<hex_prefix>` format

**Canonicalization guarantees:**
- **Dict key order is irrelevant.** Keys are sorted lexicographically before serialization.
- **Unicode is NFC-normalized.** `"café"` (precomposed) and `"café"` (decomposed e + combining accent) produce identical output.
- **Newlines are normalized to LF.** `\r\n` and `\r` are collapsed to `\n`.
- **Floats use 17-significant-digit precision.** `-0.0` collapses to `0.0`. `NaN` and `Inf` are serialized as stable strings.
- **Booleans and integers are distinct.** `True` and `1` produce different canonical bytes.
- **Bytes pass through unchanged.** Binary data is not re-encoded; hashing uses SHA-256 with a hex prefix preview for display.
- **Compact JSON encoding.** No whitespace separators (`","` and `":"`), `ensure_ascii=False`.

**Zero dependencies.** Uses only `hashlib`, `json`, `math`, `unicodedata` from the standard library.

---

### 2. Deterministic JSON Diff Patches (`forkline/core/json_diff.py`)

A recursive JSON diff algorithm that produces a **stable, ordered list of patch operations** for any two JSON-like values.

**Function:**
- `json_diff(old, new, path="$") -> List[Dict]`

**Patch operation format:**
```json
[
  {"op": "remove", "path": "$.a.b", "old": "<removed_value>"},
  {"op": "add",    "path": "$.x",   "value": "<added_value>"},
  {"op": "replace","path": "$.k",   "old": "<old_value>", "new": "<new_value>"}
]
```

**Ordering guarantees (deterministic across invocations):**
- **Dicts:** removed keys (sorted) → added keys (sorted) → common keys (sorted, recursed).
- **Lists:** compared by index; removes at tail, then adds at tail.
- **Type mismatch:** replace whole node.
- **Numeric compatibility:** `int` vs `float` compared as numeric, not as type mismatch.

**Paths use JSONPath-style notation:** `$.outer.inner`, `$.list[0]`, `$.nested.array[2].field`.

---

### 3. First-Divergence Engine (`forkline/core/first_divergence.py`)

The core diffing algorithm: compare two `Run` objects step-by-step, classify the first mismatch, and return a structured result.

#### Algorithm

1. **Lockstep comparison.** Walk both runs at the same index. At each step, classify by comparing (in priority order): step name → input hash → error state → output hash → all events hash.

2. **Resync window.** On mismatch, search within a configurable window (default W=10) for matching "soft signatures" — `(step_name, input_hash)` tuples. The search iterates by increasing combined distance from the mismatch point, finding the **nearest** resync.

3. **Gap classification.**
   - Resync with `gap_a > 0, gap_b == 0` → `missing_steps` (steps in run_a absent from run_b)
   - Resync with `gap_b > 0, gap_a == 0` → `extra_steps` (steps in run_b not in run_a)
   - Both gaps > 0 → falls through to classify the mismatch at current position
   - No resync → classify by what differs at current position

4. **Length mismatch.** If one run is longer after lockstep exhausts the shorter, classify as `missing_steps` or `extra_steps`.

#### Divergence Types

| Type | Trigger | Explanation Pattern |
|---|---|---|
| `exact_match` | Runs identical | `"Runs are identical (N steps compared)"` |
| `op_divergence` | Step names differ | `"Step 3: operation mismatch ('tool_call' vs 'llm_call')"` |
| `input_divergence` | Same name, different input | `"Step 3 'tool_call': input differs"` |
| `output_divergence` | Same name + input, different output | `"Step 3 'tool_call': output differs (same input)"` |
| `error_divergence` | Error presence or content differs | `"Step 3 'tool_call': error state differs"` |
| `missing_steps` | Steps in run_a not in run_b | `"Step 5 from run_a missing in run_b"` |
| `extra_steps` | Steps in run_b not in run_a | `"Steps 3..4 in run_b not present in run_a"` |

All explanations are **deterministic and rule-based** — no LLM narration, no randomness.

#### Classification Priority

When two steps share a name but differ, classification follows strict priority:

1. **Input divergence** — checked first because differing inputs explain differing outputs
2. **Error divergence** — error presence/absence or content differs
3. **Output divergence** — same input but different output (nondeterminism signal)
4. **All-events fallback** — catches differences in `tool_call`, `artifact_ref`, or other event types

#### Data Models

**`StepSummary`** — Compact step representation included in results:
```python
StepSummary(
    idx=2,
    name="generate_response",
    input_hash="a1b2c3d4...",
    output_hash="e5f6a7b8...",
    event_count=3,
    has_error=False,
)
```

**`FirstDivergenceResult`** — Complete result object:
```python
FirstDivergenceResult(
    status="output_divergence",        # DivergenceType
    idx_a=2,                           # Index in run_a at divergence
    idx_b=2,                           # Index in run_b at divergence
    explanation="Step 2 'generate_response': output differs (same input)",
    old_step=StepSummary(...),         # Step from run_a
    new_step=StepSummary(...),         # Step from run_b
    input_diff=None,                   # JSON patch (when applicable)
    output_diff=[{"op": "replace", "path": "$[0].text", ...}],
    last_equal_idx=1,                  # Last step where both matched
    context_a=[StepSummary(...),...],   # 2 steps before/after in run_a
    context_b=[StepSummary(...),...],   # 2 steps before/after in run_b
)
```

Both models are **frozen dataclasses** with `.to_dict()` for JSON serialization.

#### API

```python
from forkline.core.first_divergence import find_first_divergence, DivergenceType

result = find_first_divergence(
    run_a,
    run_b,
    window=10,          # Resync window size
    context_size=2,     # Steps before/after divergence in context
    show="both",        # "input", "output", or "both"
)

# JSON-serializable output
import json
print(json.dumps(result.to_dict(), indent=2))
```

---

### 4. CLI — `forkline diff` (`forkline/cli.py`)

The first CLI subcommand, establishing the `forkline` command-line interface.

**Usage:**
```bash
forkline diff --first <run_a> <run_b> [OPTIONS]
```

**Options:**

| Flag | Default | Description |
|---|---|---|
| `--first` | `true` | Show first divergence only |
| `--window N` | `10` | Resync window size |
| `--format json\|text` | `text` | Output format |
| `--show input\|output\|both` | `both` | Which diffs to include |
| `--canon strict` | `strict` | Canonicalization profile |
| `--db PATH` | `forkline.db` | SQLite database path |

**Exit codes:**
- `0` — Runs are identical (`exact_match`)
- `1` — Divergence detected (any other status)

This makes `forkline diff` directly usable in CI pipelines and shell scripts.

**Text output sample:**
```
First divergence: output_divergence
  Step 2 'generate_response': output differs (same input)

  Run A step 2 'generate_response':
    input_hash:  a1b2c3d4e5f6a7b8...
    output_hash: 1234567890abcdef...
    events: 3
    has_error: False

  Run B step 2 'generate_response':
    input_hash:  a1b2c3d4e5f6a7b8...
    output_hash: fedcba0987654321...
    events: 3
    has_error: False

  Output diff:
    replace $[0].text: "Expected response" -> "Different response"

  Last equal: step 1
  Context A: [step 0 'init', step 1 'prepare', step 2 'generate_response']
  Context B: [step 0 'init', step 1 'prepare', step 2 'generate_response']
```

**Entry point:** Registered as `forkline = "forkline.cli:main"` in `pyproject.toml` (`[project.scripts]`).

---

### 5. Module Exports

New public symbols exported from `forkline` and `forkline.core`:

| Symbol | Module | Description |
|---|---|---|
| `find_first_divergence` | `forkline.core.first_divergence` | Main engine function |
| `FirstDivergenceResult` | `forkline.core.first_divergence` | Result dataclass |
| `StepSummary` | `forkline.core.first_divergence` | Compact step summary |
| `DivergenceType` | `forkline.core.first_divergence` | Type classification constants |
| `canon` | `forkline.core.canon` | Value → canonical bytes |
| `sha256_hex` | `forkline.core.canon` | Bytes → SHA-256 hex |
| `bytes_preview` | `forkline.core.canon` | Bytes → human-readable hash preview |
| `json_diff` | `forkline.core.json_diff` | Deterministic JSON diff patches |

---

## Tests

**45 new tests** across 3 test classes in `tests/unit/test_first_divergence.py`. All hermetic — no database, no disk I/O, no network.

### TestCanonStability (14 tests)

| Test | Validates |
|---|---|
| `test_dict_key_order_irrelevant` | `{"z":1,"a":2}` == `{"a":2,"z":1}` |
| `test_nested_dict_stability` | Deep nesting with mixed key order |
| `test_unicode_normalization` | NFC: `\u00e9` == `e\u0301` |
| `test_newline_normalization` | `\r\n` and `\r` → `\n` |
| `test_float_stability` | Same float always produces same bytes |
| `test_negative_zero` | `-0.0` == `0.0` |
| `test_bytes_passthrough` | Raw bytes returned unchanged |
| `test_sha256_deterministic` | Same input → same hash, always 64 hex chars |
| `test_bytes_preview_format` | `sha256:` prefix format |
| `test_repeated_canonicalization_stable` | 100 runs → 1 unique result |
| `test_string_in_json_normalized` | Unicode normalization inside JSON values |
| `test_empty_structures` | `{}` == `{}`, `[]` == `[]`, `{}` != `[]` |
| `test_none_value` | `None` == `None` |
| `test_bool_vs_int_distinct` | `True` != `1` |

### TestJsonDiffDeterminism (15 tests)

| Test | Validates |
|---|---|
| `test_identical_values_no_diff` | No ops for equal dicts |
| `test_added_key` | `add` op with correct path and value |
| `test_removed_key` | `remove` op with correct path |
| `test_replaced_value` | `replace` op with old and new |
| `test_ordering_remove_before_add_before_common` | Stable operation ordering |
| `test_nested_diff` | Deep path: `$.outer.inner` |
| `test_list_same_length` | Index-based comparison: `$[1]` |
| `test_list_shorter` | `remove` at tail index |
| `test_list_longer` | `add` at tail index |
| `test_type_change` | `replace` on type mismatch |
| `test_deterministic_across_runs` | 100 runs → identical patches |
| `test_empty_dicts` / `test_empty_lists` | No ops for empty structures |
| `test_none_values` | No ops for `None == None` |
| `test_int_float_comparison` | Numeric cross-type comparison |

### TestFirstDivergenceEngine (16 tests)

| Test | Validates |
|---|---|
| `test_identical_runs_exact_match` | (a) `exact_match`, explanation includes step count |
| `test_output_divergence_same_input` | (b) `output_divergence`, output diff populated, `last_equal_idx` correct |
| `test_inserted_step_extra_steps` | (c) `extra_steps` at insertion point via resync |
| `test_run_b_shorter_missing_steps` | (d) `missing_steps` when run_b is truncated |
| `test_op_mismatch_no_resync` | (e) `op_divergence` with both step names in explanation |
| `test_empty_runs_match` | Edge case: two empty runs → `exact_match` |
| `test_error_divergence` | Error event in one run, output event in the other |
| `test_input_divergence` | Same step name, different input payload |
| `test_result_json_serialization` | `.to_dict()` round-trips through `json.dumps` |
| `test_context_window` | Context includes surrounding steps |
| `test_deterministic_across_invocations` | 50 runs → identical `.to_dict()` output |
| `test_run_a_shorter_extra_steps` | `extra_steps` when run_b is longer |
| `test_deleted_step_missing_steps_via_resync` | Deleted step detected via resync as `missing_steps` |
| `test_step_summary_fields` | All 6 fields present in `StepSummary.to_dict()` |
| `test_show_input_only` | `show="input"` suppresses output diff |
| `test_show_output_only` | `show="output"` suppresses input diff |

**Total test count after this release:** 187 (142 existing + 45 new). All passing.

---

## Files Changed

### New Files (5)

| File | Lines | Purpose |
|---|---|---|
| `forkline/core/canon.py` | 96 | Canonicalization + SHA-256 |
| `forkline/core/json_diff.py` | 64 | Deterministic JSON diff patches |
| `forkline/core/first_divergence.py` | 449 | Engine, data models, resync, classification |
| `forkline/cli.py` | 195 | CLI entry point (`forkline diff`) |
| `tests/unit/test_first_divergence.py` | 532 | 45 hermetic tests |

### Modified Files (4)

| File | Change |
|---|---|
| `forkline/core/__init__.py` | Added exports for canon, json_diff, first_divergence |
| `forkline/__init__.py` | Added top-level exports |
| `pyproject.toml` | Added `[project.scripts]` entry point; listed subpackages |
| `README.md` | Added "First-Divergence Diffing" section |

---

## Design Decisions

### Adaptation to Existing Data Model

The implementation adapts to Forkline's existing `Step` model (which uses `idx`, `name`, and `events: List[Event]`) rather than the spec's assumed `seq`, `op`, `kind`, `input`, `output`, `error` fields:

| Spec Field | Actual Mapping |
|---|---|
| `seq` | `Step.idx` |
| `op` | `Step.name` |
| `kind` | Not present; not needed for diffing |
| `input` | Events where `event.type == "input"` (payloads aggregated) |
| `output` | Events where `event.type == "output"` (payloads aggregated) |
| `error` | Events where `event.type == "error"` |

The soft signature for resync uses `(name, input_hash)` instead of `(op, kind, input_hash)`.

### No New Dependencies

Everything uses the Python standard library: `hashlib`, `json`, `math`, `unicodedata`, `argparse`, `dataclasses`. This preserves the project's zero-dependency constraint.

### Fallback Event Comparison

After checking input, error, and output events individually, the engine performs a **full event comparison** as a catch-all. This ensures differences in non-standard event types (`tool_call`, `artifact_ref`, etc.) are detected and reported as `output_divergence`.

### CLI Exit Codes for CI

`forkline diff` exits `0` on `exact_match` and `1` on any divergence, making it directly usable in CI pipelines: `forkline diff --first baseline current --format json || exit 1`.

---

## Invariants Preserved

- **Deterministic.** Same inputs always produce identical output. Verified by repeated-invocation tests (50-100 iterations).
- **No async.** All computation is synchronous.
- **No network calls.** The engine operates entirely on in-memory `Run` objects.
- **No mutation.** All data models are frozen dataclasses. Input runs are never modified.
- **Canonicalization before comparison.** All hashing and diffing operates on canonicalized representations.

---

## What's Next

Per the [roadmap](ROADMAP.md), remaining v0 milestones:

- **v0.4 — Minimal CLI (in progress):** `forkline diff --first` is done. `forkline run` and `forkline replay` subcommands remain.
- **v0.5 — CI-friendly mode:** Deterministic execution for tests, fail CI on unexpected diffs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new comparison logic and a new CLI surface area; while mostly additive, correctness/determinism and exit-code behavior could impact CI workflows if edge cases or run schemas differ from expectations.
> 
> **Overview**
> Implements **first-divergence diffing** for recorded runs: a new engine (`find_first_divergence`) classifies the earliest mismatch (input/output/op/error, missing/extra steps), supports a resync window for inserted/deleted steps, and returns a JSON-serializable `FirstDivergenceResult` with context and structured diff patches.
> 
> Adds deterministic primitives used by the engine (`canon`, `sha256_hex`, `json_diff`) and exposes them via `forkline`/`forkline.core` exports. Introduces an installable CLI entrypoint (`forkline diff --first`) with text/JSON output and CI-friendly exit codes, plus updates docs/roadmap and a large hermetic unit test suite covering determinism and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fc4cca9ec0a8a68c23e7be5bedb16004965a84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->