### PR TITLE
Tool invocation and redaction changes

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -1,0 +1,257 @@
+# Redaction
+
+Forkline provides deterministic, configurable redaction of sensitive data in
+run artifacts. Redaction happens at the storage boundary — raw sensitive data
+is **never** written to disk.
+
+## Design Principles
+
+- **Deterministic**: Same input + same rules = same output. Always.
+- **Fail closed**: Default policy redacts common secrets automatically.
+- **No mutation**: Input payloads are never modified; redaction returns a new copy.
+- **Before persistence**: Redaction is applied before any write to SQLite or JSON.
+- **Sorted traversal**: Dict keys are traversed in sorted order for cross-run determinism.
+
+## Matching Strategies
+
+Forkline supports three redaction strategies, applied in this order:
+
+### 1. Key-Based Matching (Structural)
+
+Matches dict keys by case-insensitive substring. If a key contains the
+pattern, the value is redacted.
+
+```yaml
+redact_keys:
+  - password
+  - token
+  - api_key
+```
+
+This matches `password`, `user_password`, `PASSWORD`, `api_key_v2`, etc.
+
+### 2. Path-Based Matching (Structural)
+
+Matches on dot-separated paths. Only redacts values at the specific
+location in the object tree.
+
+```yaml
+redact_paths:
+  - "headers.authorization"
+  - "request.params.api_key"
+```
+
+`headers.authorization` matches `{"headers": {"authorization": "..."}}` but
+**not** `{"body": {"authorization": "..."}}`.
+
+### 3. Regex-Based Matching (Value)
+
+Matches against string values using regex patterns. Applied to all string
+values that survive structural redaction.
+
+```yaml
+redact_regex:
+  - name: jwt
+    pattern: "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"
+    replacement: "[REDACTED:jwt]"
+  - name: bearer
+    pattern: "(?i)bearer\\s+[A-Za-z0-9._-]+"
+    replacement: "Bearer [REDACTED]"
+```
+
+## Rule Application Order
+
+Rules are applied deterministically:
+
+1. **Structural rules** (key/path) are evaluated per dict key, first match wins
+2. If a structural rule matches, it replaces the entire value (regex is not applied)
+3. **Regex rules** are applied in order to all surviving string values
+4. Dict keys are iterated in **sorted order** for deterministic traversal
+
+This means:
+- A key matching a structural MASK rule gets `"[REDACTED]"` — no regex processing
+- A key that doesn't match any structural rule has its string value processed by all regex rules in order
+
+## Redaction Actions
+
+| Action | Behavior |
+|--------|----------|
+| `mask` | Replace value with `"[REDACTED]"` or a custom replacement string |
+| `hash` | Replace with deterministic SHA-256: `"hash:<hex>"` |
+| `drop` | Remove the key-value pair entirely |
+
+## Configuration
+
+### Config File Format
+
+Create a `forkline.redact.yaml` (or `.json`) file:
+
+```yaml
+fields:
+  redact_keys:
+    - password
+    - passwd
+    - token
+    - api_key
+    - authorization
+    - cookie
+    - secret
+    - session
+
+  redact_paths:
+    - "tool.request.headers.Authorization"
+    - "tool.request.headers.Cookie"
+    - "tool.request.params.api_key"
+
+  redact_regex:
+    - name: jwt
+      pattern: "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"
+      replacement: "[REDACTED:jwt]"
+
+    - name: bearer
+      pattern: "(?i)bearer\\s+[A-Za-z0-9._-]+"
+      replacement: "Bearer [REDACTED]"
+
+    - name: aws_key
+      pattern: "AKIA[A-Z0-9]{16}"
+      replacement: "[REDACTED:aws_key]"
+```
+
+JSON format is also supported (no PyYAML dependency required):
+
+```json
+{
+  "fields": {
+    "redact_keys": ["password", "token", "api_key"],
+    "redact_paths": ["headers.authorization"],
+    "redact_regex": [
+      {
+        "name": "jwt",
+        "pattern": "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+",
+        "replacement": "[REDACTED:jwt]"
+      }
+    ]
+  }
+}
+```
+
+### CLI Usage
+
+```bash
+# Run with custom redaction config
+forkline run my_agent.py --redact-config forkline.redact.yaml
+
+# Replay does not require config (reads already-redacted artifacts)
+forkline replay <run_id>
+```
+
+### Programmatic Usage
+
+```python
+from forkline.core.redaction import load_redaction_config, RedactionConfig
+
+# From file
+config = load_redaction_config("forkline.redact.yaml")
+policy = config.to_policy()
+
+# From code
+config = RedactionConfig(
+    redact_keys=["password", "token"],
+    redact_paths=["headers.authorization"],
+    redact_regex=[
+        {"name": "jwt", "pattern": r"eyJ...", "replacement": "[REDACTED:jwt]"}
+    ],
+)
+policy = config.to_policy()
+
+# Use with RunRecorder
+from forkline.storage.recorder import RunRecorder
+recorder = RunRecorder(db_path="runs.db", redaction_policy=policy)
+
+# Or use the factory method
+recorder = RunRecorder.with_config(
+    db_path="runs.db",
+    redact_config_path="forkline.redact.yaml",
+)
+```
+
+## Default Policy
+
+When no custom config is provided, Forkline applies a safe default policy
+that covers common secret patterns.
+
+### Default Key Patterns (structural, MASK action)
+
+| Pattern | Matches |
+|---------|---------|
+| `key` | api_key, secret_key, etc. |
+| `token` | token, access_token, refresh_token, bearer_token |
+| `secret` | secret, client_secret, SECRET_KEY |
+| `password` | password, user_password |
+| `passwd` | passwd |
+| `api_key` | api_key |
+| `apikey` | apikey |
+| `auth` | auth, authorization, auth_token |
+| `authorization` | authorization |
+| `cookie` | cookie, set-cookie |
+| `credentials` | credentials |
+| `private_key` | private_key |
+| `privatekey` | privatekey |
+| `access_token` | access_token |
+| `refresh_token` | refresh_token |
+| `session` | session, session_id |
+| `csrf` | csrf, csrf_token |
+
+### Default Regex Patterns (value-level)
+
+| Name | Pattern | Replacement |
+|------|---------|-------------|
+| `jwt` | `eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+` | `[REDACTED:jwt]` |
+| `bearer` | `(?i)bearer\s+[A-Za-z0-9._-]+` | `Bearer [REDACTED]` |
+| `aws_key` | `AKIA[A-Z0-9]{16}` | `[REDACTED:aws_key]` |
+
+## Determinism Guarantees
+
+Forkline's redaction is fully deterministic:
+
+1. **Same input + same rules = same output** — tested and enforced
+2. **No randomness** — no random IDs, no timestamps in redaction output
+3. **Stable rule ordering** — rules are applied in the order they are defined
+4. **Sorted key traversal** — dict keys are visited in sorted order
+5. **Stable hash output** — HASH action uses `json.dumps(sort_keys=True)` for dict values
+
+This means replaying a run with the same redaction config will always produce
+identical stored artifacts.
+
+## Where Redaction Happens
+
+```
+Tool call happens
+       │
+       ▼
+Build tool_call payload (raw)
+       │
+       ▼
+apply redact(payload)  ← storage boundary
+       │
+       ▼
+Write event to SQLite
+       │
+       ▼
+Export to JSON (already redacted)
+```
+
+Raw sensitive data **never** touches disk. The redaction policy is enforced
+by `RunRecorder.log_event()` which applies `RedactionPolicy.redact()` before
+serializing the payload to JSON for SQLite insertion.
+
+## YAML Dependency
+
+YAML config files require the `pyyaml` package:
+
+```bash
+pip install pyyaml
+```
+
+JSON config files work with no additional dependencies. If you attempt to load
+a `.yaml` file without PyYAML installed, a clear error message is shown.

--- a/docs/tool_visibility.md
+++ b/docs/tool_visibility.md
@@ -1,0 +1,184 @@
+# Tool Visibility
+
+Forkline records tool invocations (DB queries, API calls, file operations) as
+first-class `tool_call` events in the run artifact. This gives agents full
+visibility into what tools did, when, and how long they took.
+
+## Event Schema
+
+Each tool invocation is captured as a single event with `type: "tool_call"`.
+This uses the **single-event model** (Option 1): one event contains both the
+request and response, linked by a stable `invocation_id`.
+
+### Payload Structure
+
+```json
+{
+  "tool_name": "http.request",
+  "invocation_id": "a1b2c3d4e5f6...",
+  "request": {
+    "url": "https://api.example.com/data",
+    "method": "GET",
+    "headers": { "Authorization": "[REDACTED]" }
+  },
+  "response": {
+    "status": 200,
+    "body": "{...}"
+  },
+  "timing": {
+    "started_at": "2026-01-15T10:30:00.000Z",
+    "ended_at": "2026-01-15T10:30:00.250Z",
+    "duration_ms": 250.0
+  },
+  "metadata": {
+    "bytes_read": 1024,
+    "cache_hit": false
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `tool_name` | string | yes | Dotted tool identifier (e.g., `bigquery.query`, `http.request`, `file.read`) |
+| `invocation_id` | string | yes | Stable UUID per call. Auto-generated if not provided. |
+| `request` | dict | yes | Request payload (redacted before persistence) |
+| `response` | dict | no | Response payload (redacted). Absent if call errored. |
+| `error` | dict | no | Error info with `type` and `message` fields. Absent on success. |
+| `timing.started_at` | string | yes | ISO8601 UTC timestamp when call started |
+| `timing.ended_at` | string | yes | ISO8601 UTC timestamp when call completed |
+| `timing.duration_ms` | float | yes | Wall-clock duration in milliseconds |
+| `metadata` | dict | no | Optional metadata: `status_code`, `row_count`, `bytes_read`, `retry_count`, `cache_hit` |
+
+### Error Events
+
+When a tool call fails, the `error` field is populated and `response` is absent:
+
+```json
+{
+  "tool_name": "http.request",
+  "invocation_id": "...",
+  "request": { "url": "https://api.example.com" },
+  "error": {
+    "type": "ConnectionError",
+    "message": "Connection refused"
+  },
+  "timing": { "started_at": "...", "ended_at": "...", "duration_ms": 5023.0 }
+}
+```
+
+## Recording Tool Calls
+
+### Context Manager (recommended)
+
+Use `ToolCallRecorder` for explicit control over request/response capture:
+
+```python
+from forkline.core.tool_call import ToolCallRecorder
+from forkline.storage.recorder import RunRecorder
+
+recorder = RunRecorder(db_path="runs.db")
+run_id = recorder.start_run("my_agent.py")
+
+with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+    tc.set_request({"url": "https://api.example.com", "method": "GET"})
+    response = requests.get("https://api.example.com")
+    tc.set_response({"status": response.status_code, "body": response.text})
+    tc.set_metadata({"bytes_read": len(response.content)})
+```
+
+Timing is captured automatically. If an exception occurs inside the `with`
+block, the error is recorded and the exception re-raised.
+
+### Decorator
+
+Use `record_tool_call` for simpler wrapping of existing functions:
+
+```python
+from forkline.core.tool_call import record_tool_call
+
+@record_tool_call(recorder, run_id, "db.query")
+def query_db(sql, params=None):
+    return db.execute(sql, params).fetchall()
+
+rows = query_db("SELECT * FROM users WHERE active = ?", params=[True])
+```
+
+The function's arguments become the request payload. The return value becomes
+the response payload (wrapped in `{"result": ...}` if not a dict).
+
+### Convenience Method
+
+Use `RunRecorder.log_tool_call()` for manual construction:
+
+```python
+recorder.log_tool_call(
+    run_id=run_id,
+    tool_name="bigquery.query",
+    request={"sql": "SELECT count(*) FROM events"},
+    response={"rows": [{"count": 42}]},
+    timing={
+        "started_at": "2026-01-15T10:30:00Z",
+        "ended_at": "2026-01-15T10:30:01Z",
+        "duration_ms": 1000
+    },
+    metadata={"row_count": 1},
+)
+```
+
+## Redaction
+
+All tool call payloads are redacted **before** persistence. Sensitive data
+in `request`, `response`, `error`, and `metadata` fields is redacted according
+to the active redaction policy. See [redaction.md](redaction.md) for details.
+
+The redaction pipeline:
+
+1. Tool call happens (raw data)
+2. Build `tool_call` payload
+3. Apply `redact(payload)` at storage boundary
+4. Write redacted event to SQLite
+5. Raw sensitive data is **never** stored
+
+## Replay Integration
+
+During replay, `ToolCallRecorder` enforces determinism guardrails:
+
+- **Replay mode active**: `ToolCallRecorder.__enter__()` raises
+  `DeterminismViolationError` to prevent live tool calls.
+- **Re-exec mode**: Set `allow_in_replay=True` to permit tool execution
+  during replay (the call is still recorded with redaction).
+- **Recorded response substitution**: Use `ReplayContext.get_events_by_type()`
+  to retrieve recorded `tool_call` events and inject their responses.
+
+```python
+from forkline.core.replay import replay_mode
+
+with replay_mode("run-abc123"):
+    # This raises DeterminismViolationError:
+    with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+        ...
+
+    # This is allowed (re-exec mode):
+    with ToolCallRecorder(recorder, run_id, "http.request", allow_in_replay=True) as tc:
+        ...
+```
+
+## Event Ordering
+
+Tool call events maintain strict monotonic ordering via SQLite's
+auto-incrementing `event_id`. This guarantees:
+
+- Events are stored in the order they occurred
+- Replay can reconstruct the exact sequence of tool calls
+- `event_id` ordering matches wall-clock ordering within a run
+
+## Storage
+
+Tool call events are stored in both:
+
+- **SQLite** (`events` table): For efficient querying and local replay
+- **JSON export** (`RunArtifact.to_json()`): For portable artifact exchange
+
+Both formats preserve the full `tool_call` payload structure.

--- a/examples/tool_call_basic.py
+++ b/examples/tool_call_basic.py
@@ -1,0 +1,75 @@
+"""
+Basic tool call recording example.
+
+Demonstrates the three ways to record tool calls:
+1. ToolCallRecorder context manager
+2. record_tool_call decorator
+3. RunRecorder.log_tool_call() convenience method
+
+Run:
+    python examples/tool_call_basic.py
+
+Inspect:
+    sqlite3 runs.db \
+      "SELECT json_extract(payload, '$.tool_name') as tool, \
+              json_extract(payload, '$.timing.duration_ms') as ms \
+       FROM events WHERE type='tool_call';"
+"""
+
+import json
+import os
+import tempfile
+import time
+
+from forkline.core.redaction import RedactionPolicy
+from forkline.core.tool_call import ToolCallRecorder, record_tool_call
+from forkline.storage.recorder import RunRecorder
+
+
+def main() -> None:
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "demo.db")
+    recorder = RunRecorder(
+        db_path=db_path,
+        redaction_policy=RedactionPolicy(rules=[]),
+    )
+    run_id = recorder.start_run("examples/tool_call_basic.py")
+
+    # --- 1. Context manager ---
+    with ToolCallRecorder(recorder, run_id, "http.get") as tc:
+        tc.set_request({"url": "https://api.example.com/users"})
+        time.sleep(0.01)  # simulate latency
+        tc.set_response({"status": 200, "count": 42})
+        tc.set_metadata({"bytes_read": 2048})
+
+    # --- 2. Decorator ---
+    @record_tool_call(recorder, run_id, "math.multiply")
+    def multiply(a, b):
+        return a * b
+
+    multiply(6, 7)
+
+    # --- 3. Convenience method ---
+    recorder.log_tool_call(
+        run_id=run_id,
+        tool_name="file.read",
+        request={"path": "/etc/hostname"},
+        response={"content": "myhost"},
+        metadata={"bytes_read": 6},
+    )
+
+    recorder.end_run(run_id)
+
+    # Print what was stored
+    events = recorder.get_events(run_id)
+    print(f"Recorded {len(events)} tool call events:\n")
+    for e in events:
+        p = e["payload"]
+        ms = p["timing"].get("duration_ms", "n/a")
+        print(f"  {p['tool_name']:20s}  {ms:>8} ms")
+    print()
+    print(json.dumps(events[0]["payload"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tool_call_production.py
+++ b/examples/tool_call_production.py
@@ -1,0 +1,295 @@
+"""
+Production-grade tool call recording with redaction.
+
+Simulates a realistic agentic workflow that:
+1. Calls an LLM to plan a query
+2. Executes a database query
+3. Calls an external HTTP API with auth headers
+4. Writes results to a file
+5. Handles a failing tool call gracefully
+
+All tool calls are recorded with full timing, metadata, and
+deterministic redaction of secrets (API keys, tokens, JWTs,
+auth headers) before anything touches disk.
+
+Run:
+    python examples/tool_call_production.py
+
+Inspect:
+    python -c "
+    from forkline.storage.recorder import RunRecorder
+    r = RunRecorder(db_path='/tmp/forkline_prod_demo/runs.db')
+    for run in r.list_runs():
+        print(run['run_id'][:12], run['status'])
+        for e in r.get_events(run['run_id']):
+            if e['type'] == 'tool_call':
+                p = e['payload']
+                print(f'  {p[\"tool_name\"]:25s}  '
+                      f'{p[\"timing\"][\"duration_ms\"]:8.1f}ms')
+    "
+"""
+
+import json
+import os
+import shutil
+import time
+
+from forkline.core.redaction import (
+    RegexRedactionRule,
+    create_default_policy,
+)
+from forkline.core.tool_call import ToolCallRecorder, record_tool_call
+from forkline.storage.recorder import RunRecorder
+
+# ── Simulated external services ───────────────────────────
+
+
+def _sim_llm(prompt: str) -> dict:
+    """Simulate an LLM API call."""
+    time.sleep(0.02)
+    return {
+        "model": "gpt-4",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": (
+                        "SELECT u.id, u.email, o.total "
+                        "FROM users u JOIN orders o "
+                        "ON u.id = o.user_id "
+                        "WHERE o.created_at > '2026-01-01'"
+                    ),
+                }
+            }
+        ],
+        "usage": {"prompt_tokens": 45, "completion_tokens": 32},
+    }
+
+
+def _sim_db_query(sql: str) -> dict:
+    """Simulate a database query."""
+    time.sleep(0.015)
+    return {
+        "columns": ["id", "email", "total"],
+        "rows": [
+            [1, "alice@corp.com", 149.99],
+            [2, "bob@startup.io", 89.50],
+            [3, "carol@enterprise.co", 320.00],
+        ],
+        "row_count": 3,
+        "query_time_ms": 12.4,
+    }
+
+
+def _sim_http_post(url: str, headers: dict, body: dict) -> dict:
+    """Simulate an HTTP POST to an external webhook."""
+    time.sleep(0.01)
+    return {
+        "status_code": 202,
+        "body": {"accepted": True, "id": "evt_abc123"},
+    }
+
+
+def _sim_file_write(path: str, content: str) -> dict:
+    """Simulate writing a report file."""
+    time.sleep(0.005)
+    return {"bytes_written": len(content), "path": path}
+
+
+def _sim_failing_call() -> dict:
+    """Simulate a tool call that fails."""
+    time.sleep(0.008)
+    raise ConnectionError("upstream service unavailable (503)")
+
+
+# ── Agent workflow ────────────────────────────────────────
+
+
+def run_agent():
+    db_dir = "/tmp/forkline_prod_demo"
+    if os.path.exists(db_dir):
+        shutil.rmtree(db_dir)
+    os.makedirs(db_dir)
+
+    # Production redaction: default policy + custom regex for
+    # connection strings with embedded credentials
+    policy = create_default_policy()
+    policy.regex_rules.append(
+        RegexRedactionRule.from_config(
+            name="connection_string",
+            pattern_str=r"://[^:]+:[^@]+@",
+            replacement="://[REDACTED:credentials]@",
+        )
+    )
+
+    recorder = RunRecorder(
+        db_path=os.path.join(db_dir, "runs.db"),
+        redaction_policy=policy,
+    )
+    run_id = recorder.start_run("examples/tool_call_production.py")
+    print(f"Run started: {run_id[:12]}...\n")
+
+    # ── Step 1: LLM planning call ──
+    print("1. Calling LLM for query planning...")
+    with ToolCallRecorder(recorder, run_id, "llm.chat") as tc:
+        tc.set_request(
+            {
+                "model": "gpt-4",
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a SQL assistant.",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Get all users with orders in 2026",
+                    },
+                ],
+                "api_key": "sk-proj-REAL_SECRET_KEY_HERE",
+            }
+        )
+        result = _sim_llm("Get all users with orders in 2026")
+        tc.set_response(result)
+        tc.set_metadata(
+            {
+                "prompt_tokens": result["usage"]["prompt_tokens"],
+                "completion_tokens": result["usage"]["completion_tokens"],
+            }
+        )
+    sql = result["choices"][0]["message"]["content"]
+    print(f"   SQL: {sql[:50]}...")
+
+    # ── Step 2: Database query ──
+    print("2. Executing database query...")
+    with ToolCallRecorder(recorder, run_id, "postgres.query") as tc:
+        tc.set_request(
+            {
+                "sql": sql,
+                "connection_string": "postgresql://admin:s3cret@db.internal:5432/prod",
+            }
+        )
+        db_result = _sim_db_query(sql)
+        tc.set_response(db_result)
+        tc.set_metadata(
+            {
+                "row_count": db_result["row_count"],
+                "query_time_ms": db_result["query_time_ms"],
+            }
+        )
+    print(f"   Got {db_result['row_count']} rows")
+
+    # ── Step 3: HTTP webhook with auth ──
+    print("3. Posting results to webhook...")
+    jwt_token = (
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"
+        ".eyJzdWIiOiJhZ2VudC0xIiwiZXhwIjoxNzM3MjAwMDAwfQ"
+        ".kR9x7Yz_signature_bytes"
+    )
+    with ToolCallRecorder(recorder, run_id, "http.post") as tc:
+        tc.set_request(
+            {
+                "url": "https://hooks.slack.com/workflows/T123/ABC",
+                "headers": {
+                    "Authorization": f"Bearer {jwt_token}",
+                    "Content-Type": "application/json",
+                    "X-Api-Key": "whsec_live_key_456",
+                    "Cookie": "session=sess_abc123; csrf=tok_xyz",
+                },
+                "body": {
+                    "text": f"Query returned {db_result['row_count']} rows",
+                    "rows": db_result["rows"],
+                },
+            }
+        )
+        http_result = _sim_http_post(
+            "https://hooks.slack.com/workflows/T123/ABC",
+            headers={},
+            body={},
+        )
+        tc.set_response(http_result)
+        tc.set_metadata({"status_code": http_result["status_code"]})
+    print(f"   Webhook accepted: {http_result['body']['id']}")
+
+    # ── Step 4: File write ──
+    print("4. Writing report file...")
+    report = json.dumps(db_result["rows"], indent=2)
+
+    @record_tool_call(recorder, run_id, "file.write")
+    def write_report(path, content):
+        return _sim_file_write(path, content)
+
+    file_result = write_report(
+        path="/tmp/forkline_prod_demo/report.json",
+        content=report,
+    )
+    print(f"   Wrote {file_result['bytes_written']} bytes")
+
+    # ── Step 5: Failing tool call ──
+    print("5. Calling flaky upstream service...")
+    with ToolCallRecorder(recorder, run_id, "http.get") as tc:
+        tc.set_request(
+            {
+                "url": "https://flaky-api.internal/status",
+                "headers": {
+                    "Authorization": "Bearer internal-service-token",
+                },
+            }
+        )
+        try:
+            _sim_failing_call()
+        except ConnectionError as e:
+            tc.set_error({"type": type(e).__name__, "message": str(e)})
+            tc.set_metadata({"retry_count": 3})
+            print(f"   Failed: {e}")
+
+    recorder.end_run(run_id, status="success")
+
+    # ── Inspect what was stored ──
+    print("\n" + "=" * 60)
+    print("STORED EVENTS (after redaction)")
+    print("=" * 60 + "\n")
+
+    events = recorder.get_events(run_id)
+    for i, e in enumerate(events):
+        if e["type"] != "tool_call":
+            continue
+        p = e["payload"]
+        ms = p["timing"].get("duration_ms", 0)
+        status = "error" if p.get("error") else "ok"
+        print(f"Event {i}: {p['tool_name']:25s} " f"{ms:8.1f}ms  [{status}]")
+
+    print("\n--- Full HTTP POST event (redacted) ---\n")
+    http_event = [e for e in events if e["payload"].get("tool_name") == "http.post"][0]
+    print(json.dumps(http_event["payload"], indent=2))
+
+    # ── Verify no secrets in storage ──
+    print("\n--- Security verification ---\n")
+    all_json = json.dumps([e["payload"] for e in events])
+    secrets = [
+        "sk-proj-REAL_SECRET_KEY_HERE",
+        "s3cret",
+        "whsec_live_key_456",
+        "sess_abc123",
+        "internal-service-token",
+    ]
+    leaked = [s for s in secrets if s in all_json]
+    if leaked:
+        print(f"LEAKED secrets: {leaked}")
+    else:
+        print("No secrets leaked to storage.")
+
+    has_jwt = "eyJhbGciOiJSUzI1NiI" in all_json
+    print(f"JWT tokens in storage: {'YES (LEAK!)' if has_jwt else 'No'}")
+
+    # ── JSON export ──
+    print("\n--- JSON artifact export ---\n")
+    artifact_json = recorder.export_artifact_json(run_id)
+    artifact = json.loads(artifact_json)
+    tool_events = [e for e in artifact["events"] if e["type"] == "tool_call"]
+    print(f"Exported {len(tool_events)} tool_call events")
+    print(f"Artifact schema: {artifact['schema_version']}")
+    print(f"Total artifact size: {len(artifact_json)} bytes")
+
+
+if __name__ == "__main__":
+    run_agent()

--- a/forkline/__init__.py
+++ b/forkline/__init__.py
@@ -7,10 +7,16 @@ from .core import (
     FirstDivergenceResult,
     # Redaction
     RedactionAction,
+    RedactionConfig,
     RedactionRule,
+    RegexRedactionRule,
     Run,
     Step,
     StepSummary,
+    # Tool call instrumentation
+    ToolCallPayload,
+    ToolCallRecorder,
+    ToolCallTiming,
     # Canonicalization
     canon,
     create_default_policy,
@@ -18,6 +24,8 @@ from .core import (
     diff_runs,
     find_first_divergence,
     json_diff,
+    load_redaction_config,
+    record_tool_call,
     sha256_hex,
 )
 from .core.redaction import RedactionPolicy
@@ -93,9 +101,17 @@ __all__ = [
     "DivergenceType",
     # Redaction
     "RedactionAction",
+    "RedactionConfig",
     "RedactionPolicy",
     "RedactionRule",
+    "RegexRedactionRule",
     "create_default_policy",
+    "load_redaction_config",
+    # Tool call instrumentation
+    "ToolCallPayload",
+    "ToolCallRecorder",
+    "ToolCallTiming",
+    "record_tool_call",
     # Replay exceptions
     "ReplayError",
     "MissingArtifactError",

--- a/forkline/cli/__init__.py
+++ b/forkline/cli/__init__.py
@@ -31,6 +31,11 @@ from .render import (
 
 
 def _get_recorder(args: argparse.Namespace) -> RunRecorder:
+    redact_config = getattr(args, "redact_config", None)
+    if redact_config:
+        return RunRecorder.with_config(
+            db_path=args.db, redact_config_path=redact_config
+        )
     return RunRecorder(db_path=args.db)
 
 
@@ -93,6 +98,8 @@ def _cmd_run(args: argparse.Namespace) -> None:
     env["FORKLINE_TRACING"] = "1"
     env["FORKLINE_RUN_ID"] = run_id
     env["FORKLINE_DB"] = args.db
+    if getattr(args, "redact_config", None):
+        env["FORKLINE_REDACT_CONFIG"] = args.redact_config
 
     try:
         result = subprocess.run(
@@ -203,6 +210,11 @@ def main(argv: list[str] | None = None) -> None:
         "script_args",
         nargs=argparse.REMAINDER,
         help="Arguments to pass to the script (use -- to separate)",
+    )
+    run_parser.add_argument(
+        "--redact-config",
+        default=None,
+        help="Path to redaction config file (YAML or JSON)",
     )
     run_parser.set_defaults(func=_cmd_run)
 

--- a/forkline/core/__init__.py
+++ b/forkline/core/__init__.py
@@ -11,9 +11,12 @@ from .first_divergence import (
 from .json_diff import json_diff
 from .redaction import (
     RedactionAction,
+    RedactionConfig,
     RedactionPolicy,
     RedactionRule,
+    RegexRedactionRule,
     create_default_policy,
+    load_redaction_config,
 )
 from .replay import (
     # Exceptions
@@ -45,6 +48,12 @@ from .replay import (
     replay,
     replay_mode,
 )
+from .tool_call import (
+    ToolCallPayload,
+    ToolCallRecorder,
+    ToolCallTiming,
+    record_tool_call,
+)
 from .types import Event, Run, Step
 
 __all__ = [
@@ -66,9 +75,17 @@ __all__ = [
     "json_diff",
     # Redaction
     "RedactionAction",
+    "RedactionConfig",
     "RedactionPolicy",
     "RedactionRule",
+    "RegexRedactionRule",
     "create_default_policy",
+    "load_redaction_config",
+    # Tool call instrumentation
+    "ToolCallPayload",
+    "ToolCallRecorder",
+    "ToolCallTiming",
+    "record_tool_call",
     # Replay exceptions
     "ReplayError",
     "MissingArtifactError",

--- a/forkline/core/redaction.py
+++ b/forkline/core/redaction.py
@@ -1,22 +1,35 @@
 """
-RedactionPolicy v0: Deterministic, security-critical data redaction.
+RedactionPolicy: Deterministic, security-critical data redaction.
 
 Redaction occurs at the storage boundary. All payloads are redacted before
 persistence. This is a pure, deterministic compiler pass - no I/O, no randomness.
 
 Design principles:
 - Explicit over clever
-- Deterministic (same input → same output)
+- Deterministic (same input → same output, sorted key traversal)
 - No mutation of inputs
 - Human-inspectable output
 - Security-focused (fail closed)
+
+Supports three matching strategies:
+1. Key-based: case-insensitive substring match on dict key names
+2. Path-based: case-insensitive substring match on dotted paths
+3. Regex-based: regex match on string values (e.g., JWTs, Bearer tokens)
+
+Rules are applied in deterministic order:
+- Structural rules (key/path) are evaluated per dict key, first match wins
+- Regex rules are applied to all surviving string values, in rule order
+
+Dict keys are traversed in sorted order for cross-run determinism.
 """
 
 from __future__ import annotations
 
 import copy
 import hashlib
-from dataclasses import dataclass
+import json
+import re
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -24,7 +37,7 @@ from typing import Any, Dict, List, Optional
 class RedactionAction(str, Enum):
     """Action to take when a redaction rule matches."""
 
-    MASK = "mask"  # Replace with "[REDACTED]"
+    MASK = "mask"  # Replace with "[REDACTED]" or custom replacement
     HASH = "hash"  # Replace with deterministic SHA-256 hash
     DROP = "drop"  # Remove the field entirely
 
@@ -40,11 +53,15 @@ class RedactionRule:
 
     Both patterns are optional. If both are specified, BOTH must match.
     If neither is specified, the rule never matches.
+
+    replacement: Custom replacement string (default: "[REDACTED]").
+                 Only used with MASK action.
     """
 
     action: RedactionAction
     key_pattern: Optional[str] = None
     path_pattern: Optional[str] = None
+    replacement: str = "[REDACTED]"
 
     def __post_init__(self):
         """Validate that at least one pattern is specified."""
@@ -52,24 +69,99 @@ class RedactionRule:
             raise ValueError("RedactionRule requires at least one pattern")
 
 
+@dataclass(frozen=True)
+class RegexRedactionRule:
+    """
+    A regex-based redaction rule for string values.
+
+    Applied to all string values after structural (key/path) redaction.
+    Matches are replaced with the given replacement string.
+
+    Attributes:
+        name: Human-readable name for this rule (e.g., "jwt", "bearer").
+        pattern: Compiled regex pattern.
+        replacement: Replacement string for matches.
+    """
+
+    name: str
+    pattern: re.Pattern
+    replacement: str
+
+    @classmethod
+    def from_config(
+        cls, name: str, pattern_str: str, replacement: str
+    ) -> "RegexRedactionRule":
+        return cls(name=name, pattern=re.compile(pattern_str), replacement=replacement)
+
+
+@dataclass
+class RedactionConfig:
+    """
+    Complete redaction configuration loaded from a config file.
+
+    Aggregates structural rules (key/path) and regex rules into a
+    single deterministic config object.
+    """
+
+    redact_keys: List[str] = field(default_factory=list)
+    redact_paths: List[str] = field(default_factory=list)
+    redact_regex: List[Dict[str, str]] = field(default_factory=list)
+
+    def to_policy(self) -> "RedactionPolicy":
+        """Convert config to a RedactionPolicy."""
+        structural_rules: List[RedactionRule] = []
+
+        for key in self.redact_keys:
+            structural_rules.append(
+                RedactionRule(action=RedactionAction.MASK, key_pattern=key)
+            )
+
+        for path in self.redact_paths:
+            structural_rules.append(
+                RedactionRule(action=RedactionAction.MASK, path_pattern=path)
+            )
+
+        regex_rules: List[RegexRedactionRule] = []
+        for entry in self.redact_regex:
+            regex_rules.append(
+                RegexRedactionRule.from_config(
+                    name=entry["name"],
+                    pattern_str=entry["pattern"],
+                    replacement=entry.get("replacement", f"[REDACTED:{entry['name']}]"),
+                )
+            )
+
+        return RedactionPolicy(rules=structural_rules, regex_rules=regex_rules)
+
+
 class RedactionPolicy:
     """
     Deterministic redaction policy.
 
-    Applies rules in order to event payloads. The first matching rule wins.
+    Applies rules in order to event payloads. The first matching rule wins
+    for structural (key/path) rules. Regex rules are applied to all string
+    values that survive structural redaction.
+
+    Dict keys are traversed in sorted order for cross-run determinism.
 
     This is a pure function: same input → same output.
     No I/O. No randomness. No mutation of inputs.
     """
 
-    def __init__(self, rules: List[RedactionRule]):
+    def __init__(
+        self,
+        rules: List[RedactionRule],
+        regex_rules: Optional[List[RegexRedactionRule]] = None,
+    ):
         """
         Create a redaction policy.
 
         Args:
-            rules: Ordered list of redaction rules (first match wins)
+            rules: Ordered list of structural redaction rules (first match wins)
+            regex_rules: Ordered list of regex rules applied to string values
         """
         self.rules = rules
+        self.regex_rules: List[RegexRedactionRule] = regex_rules or []
 
     def redact(self, event_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -82,126 +174,85 @@ class RedactionPolicy:
         Returns:
             Redacted payload (new dict, input not mutated)
         """
-        # Deep copy to ensure no mutation of input
         redacted = copy.deepcopy(payload)
-
-        # Apply redaction recursively
         return self._redact_value(redacted, path="")
 
     def _redact_value(self, value: Any, path: str) -> Any:
-        """
-        Recursively redact a value.
-
-        Args:
-            value: Value to redact (dict, list, or primitive)
-            path: Current dot-separated path (for path_pattern matching)
-
-        Returns:
-            Redacted value
-        """
         if isinstance(value, dict):
             return self._redact_dict(value, path)
         elif isinstance(value, list):
             return self._redact_list(value, path)
+        elif isinstance(value, str):
+            return self._apply_regex_rules(value)
         else:
-            # Primitives: check if current path should be redacted
-            # (relevant when called from _redact_dict with a specific key)
             return value
 
     def _redact_dict(self, d: Dict[str, Any], path: str) -> Dict[str, Any]:
         """
         Redact a dictionary by applying rules to each key-value pair.
 
-        Args:
-            d: Dictionary to redact
-            path: Current dot-separated path
-
-        Returns:
-            Redacted dictionary
+        Keys are iterated in sorted order for deterministic traversal
+        regardless of dict construction order.
         """
         result = {}
 
-        for key, value in d.items():
-            # Build full path for this key
+        for key in sorted(d.keys()):
+            value = d[key]
             current_path = f"{path}.{key}" if path else key
 
-            # Check if this key should be redacted
             matched_rule = self._find_matching_rule(key, current_path)
 
             if matched_rule is None:
-                # No match: recursively redact the value
                 result[key] = self._redact_value(value, current_path)
             elif matched_rule.action == RedactionAction.DROP:
-                # Drop: omit the key entirely
                 pass
             elif matched_rule.action == RedactionAction.MASK:
-                # Mask: replace with sentinel
-                result[key] = "[REDACTED]"
+                result[key] = matched_rule.replacement
             elif matched_rule.action == RedactionAction.HASH:
-                # Hash: deterministic SHA-256
                 result[key] = self._hash_value(value)
 
         return result
 
     def _redact_list(self, lst: List[Any], path: str) -> List[Any]:
-        """
-        Redact a list by recursively redacting each element.
-
-        Args:
-            lst: List to redact
-            path: Current dot-separated path
-
-        Returns:
-            Redacted list
-        """
         return [self._redact_value(item, path) for item in lst]
 
+    def _apply_regex_rules(self, value: str) -> str:
+        """
+        Apply regex redaction rules to a string value.
+
+        Rules are applied in order. Each rule's replacement is applied
+        to the full string. This is deterministic: same rules in same
+        order on same string always produce the same output.
+        """
+        result = value
+        for rule in self.regex_rules:
+            result = rule.pattern.sub(rule.replacement, result)
+        return result
+
     def _find_matching_rule(self, key: str, path: str) -> Optional[RedactionRule]:
-        """
-        Find the first rule that matches the given key and path.
-
-        Args:
-            key: Key name
-            path: Dot-separated path
-
-        Returns:
-            First matching rule, or None if no match
-        """
         for rule in self.rules:
-            # Check key_pattern (case-insensitive substring match)
             key_matches = (
                 rule.key_pattern is None or rule.key_pattern.lower() in key.lower()
             )
-
-            # Check path_pattern (case-insensitive substring match)
             path_matches = (
                 rule.path_pattern is None or rule.path_pattern.lower() in path.lower()
             )
-
-            # Both must match (if specified)
             if key_matches and path_matches:
                 return rule
-
         return None
 
     def _hash_value(self, value: Any) -> str:
         """
         Create a deterministic hash of a value.
 
-        Args:
-            value: Value to hash
-
-        Returns:
-            Hex-encoded SHA-256 hash prefixed with "hash:"
+        Uses json.dumps with sort_keys for stable serialization of dicts,
+        falling back to repr for non-JSON-serializable values.
         """
-        # Serialize value to stable string representation
-        # Use repr for determinism (same value → same repr)
-        serialized = repr(value).encode("utf-8")
-
-        # Compute SHA-256
+        try:
+            serialized = json.dumps(value, sort_keys=True, default=str).encode("utf-8")
+        except (TypeError, ValueError):
+            serialized = repr(value).encode("utf-8")
         digest = hashlib.sha256(serialized).hexdigest()
-
-        # Prefix for clarity
         return f"hash:{digest}"
 
 
@@ -209,36 +260,120 @@ def create_default_policy() -> RedactionPolicy:
     """
     Create the default SAFE mode redaction policy.
 
-    This policy implements the SAFE mode behavior described in REDACTION_POLICY.md:
-    - Masks secrets (env keys, headers, tokens)
-    - Masks sensitive tool arguments
-    - Prevents credential leakage
+    Default redaction covers:
+    - Key-based: password, passwd, token, api_key, apikey, authorization,
+      cookie, set-cookie, secret, credentials, private_key, privatekey,
+      access_token, refresh_token, session, csrf, key, auth
+    - Regex-based: JWTs (eyJ...), Bearer tokens, AWS access keys
 
     Returns:
         Default RedactionPolicy for production use
     """
-    rules = [
-        # Environment variables containing secrets
+    structural_rules = [
         RedactionRule(action=RedactionAction.MASK, key_pattern="key"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="token"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="secret"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="password"),
+        RedactionRule(action=RedactionAction.MASK, key_pattern="passwd"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="api_key"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="apikey"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="auth"),
-        # HTTP headers
         RedactionRule(action=RedactionAction.MASK, key_pattern="authorization"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="cookie"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="set-cookie"),
-        # Common credential fields
         RedactionRule(action=RedactionAction.MASK, key_pattern="credentials"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="private_key"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="privatekey"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="access_token"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="refresh_token"),
-        # Session identifiers
         RedactionRule(action=RedactionAction.MASK, key_pattern="session"),
         RedactionRule(action=RedactionAction.MASK, key_pattern="csrf"),
     ]
 
-    return RedactionPolicy(rules)
+    regex_rules = [
+        RegexRedactionRule.from_config(
+            name="jwt",
+            pattern_str=r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+            replacement="[REDACTED:jwt]",
+        ),
+        RegexRedactionRule.from_config(
+            name="bearer",
+            pattern_str=r"(?i)bearer\s+[A-Za-z0-9._\-]+",
+            replacement="Bearer [REDACTED]",
+        ),
+        RegexRedactionRule.from_config(
+            name="aws_key",
+            pattern_str=r"AKIA[A-Z0-9]{16}",
+            replacement="[REDACTED:aws_key]",
+        ),
+    ]
+
+    return RedactionPolicy(rules=structural_rules, regex_rules=regex_rules)
+
+
+def load_redaction_config(path: str) -> RedactionConfig:
+    """
+    Load a RedactionConfig from a YAML or JSON file.
+
+    YAML requires the ``pyyaml`` package. JSON is always available.
+    File format is detected by extension (.yaml/.yml for YAML, .json for JSON).
+
+    Config file schema::
+
+        fields:
+          redact_keys:
+            - password
+            - token
+          redact_paths:
+            - "tool.request.headers.Authorization"
+          redact_regex:
+            - name: jwt
+              pattern: "eyJ..."
+              replacement: "[REDACTED:jwt]"
+
+    Args:
+        path: Path to config file
+
+    Returns:
+        RedactionConfig
+
+    Raises:
+        FileNotFoundError: If file does not exist
+        ValueError: If file format is unsupported or content is invalid
+    """
+    import os
+
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Redaction config not found: {path}")
+
+    ext = os.path.splitext(path)[1].lower()
+
+    with open(path, "r", encoding="utf-8") as f:
+        raw_text = f.read()
+
+    if ext in (".yaml", ".yml"):
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError:
+            raise ImportError(
+                "PyYAML is required for YAML config files. "
+                "Install it with: pip install pyyaml"
+            )
+        data = yaml.safe_load(raw_text)
+    elif ext == ".json":
+        data = json.loads(raw_text)
+    else:
+        raise ValueError(
+            f"Unsupported config file extension: {ext}. Use .yaml, .yml, or .json"
+        )
+
+    if data is None:
+        data = {}
+
+    fields = data.get("fields", data)
+
+    return RedactionConfig(
+        redact_keys=fields.get("redact_keys", []),
+        redact_paths=fields.get("redact_paths", []),
+        redact_regex=fields.get("redact_regex", []),
+    )

--- a/forkline/core/tool_call.py
+++ b/forkline/core/tool_call.py
@@ -1,0 +1,254 @@
+"""
+Tool call instrumentation for Forkline.
+
+Records tool invocations (request + response + error + timing) as first-class
+events in the run artifact. Uses Option 1: single event per tool call containing
+both request and response fields.
+
+Design:
+- Single ``tool_call`` event per invocation (not split into request/response)
+- Deterministic invocation IDs (UUID4 hex, generated once per call)
+- Timing captured via monotonic clock for duration, wall clock for timestamps
+- Integrates with RunRecorder for automatic redaction at storage boundary
+
+Usage as context manager::
+
+    with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+        tc.set_request({"url": url, "headers": headers})
+        response = requests.get(url, headers=headers)
+        tc.set_response({"status": response.status_code, "body": response.text})
+
+Usage as decorator::
+
+    @record_tool_call(recorder, run_id, "bigquery.query")
+    def run_query(sql):
+        return client.query(sql).result()
+
+Replay integration:
+    During replay, ToolCallRecorder checks replay mode and can substitute
+    recorded responses instead of executing live calls.
+"""
+
+from __future__ import annotations
+
+import functools
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+from ..core.replay import guard_live_call
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@dataclass
+class ToolCallTiming:
+    """Timing information for a tool invocation."""
+
+    started_at: str = ""
+    ended_at: str = ""
+    duration_ms: float = 0.0
+
+
+@dataclass
+class ToolCallPayload:
+    """
+    Canonical payload structure for a tool_call event.
+
+    This is the single-event representation (Option 1): one event
+    captures the full lifecycle of a tool invocation.
+    """
+
+    tool_name: str
+    invocation_id: str
+    request: Dict[str, Any] = field(default_factory=dict)
+    response: Optional[Dict[str, Any]] = None
+    error: Optional[Dict[str, Any]] = None
+    timing: ToolCallTiming = field(default_factory=ToolCallTiming)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict. Omits None fields."""
+        result: Dict[str, Any] = {
+            "tool_name": self.tool_name,
+            "invocation_id": self.invocation_id,
+            "request": self.request,
+            "timing": {
+                "started_at": self.timing.started_at,
+                "ended_at": self.timing.ended_at,
+                "duration_ms": self.timing.duration_ms,
+            },
+        }
+        if self.response is not None:
+            result["response"] = self.response
+        if self.error is not None:
+            result["error"] = self.error
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ToolCallPayload":
+        """Reconstruct from a dict, ignoring unknown fields."""
+        timing_data = data.get("timing", {})
+        return cls(
+            tool_name=data.get("tool_name", ""),
+            invocation_id=data.get("invocation_id", ""),
+            request=data.get("request", {}),
+            response=data.get("response"),
+            error=data.get("error"),
+            timing=ToolCallTiming(
+                started_at=timing_data.get("started_at", ""),
+                ended_at=timing_data.get("ended_at", ""),
+                duration_ms=timing_data.get("duration_ms", 0.0),
+            ),
+            metadata=data.get("metadata", {}),
+        )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ToolCallRecorder:
+    """
+    Context manager that records a tool invocation as a single event.
+
+    Captures timing automatically. Handles errors gracefully by recording
+    the error payload instead of the response. The event is written to the
+    recorder on exit, after redaction is applied at the storage boundary.
+
+    In replay mode, raises DeterminismViolationError on __enter__ unless
+    ``allow_in_replay=True`` is set (for re-exec mode).
+
+    Example::
+
+        with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+            tc.set_request({"url": "https://api.example.com", "method": "GET"})
+            resp = requests.get("https://api.example.com")
+            tc.set_response({"status": resp.status_code, "body": resp.text})
+            tc.set_metadata({"bytes_read": len(resp.content)})
+    """
+
+    def __init__(
+        self,
+        recorder: Any,
+        run_id: str,
+        tool_name: str,
+        *,
+        allow_in_replay: bool = False,
+    ):
+        self._recorder = recorder
+        self._run_id = run_id
+        self._tool_name = tool_name
+        self._allow_in_replay = allow_in_replay
+        self._invocation_id = uuid.uuid4().hex
+        self._request: Dict[str, Any] = {}
+        self._response: Optional[Dict[str, Any]] = None
+        self._error: Optional[Dict[str, Any]] = None
+        self._metadata: Dict[str, Any] = {}
+        self._start_time: float = 0.0
+        self._started_at: str = ""
+        self._ended_at: str = ""
+
+    def set_request(self, request: Dict[str, Any]) -> None:
+        self._request = request
+
+    def set_response(self, response: Dict[str, Any]) -> None:
+        self._response = response
+
+    def set_error(self, error: Dict[str, Any]) -> None:
+        self._error = error
+
+    def set_metadata(self, metadata: Dict[str, Any]) -> None:
+        self._metadata.update(metadata)
+
+    def __enter__(self) -> "ToolCallRecorder":
+        if not self._allow_in_replay:
+            guard_live_call(f"tool call: {self._tool_name}")
+        self._started_at = _utc_now()
+        self._start_time = time.monotonic()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        end_time = time.monotonic()
+        self._ended_at = _utc_now()
+        duration_ms = round((end_time - self._start_time) * 1000, 3)
+
+        if exc_val is not None and self._error is None:
+            self._error = {
+                "type": type(exc_val).__name__,
+                "message": str(exc_val),
+            }
+
+        payload = ToolCallPayload(
+            tool_name=self._tool_name,
+            invocation_id=self._invocation_id,
+            request=self._request,
+            response=self._response,
+            error=self._error,
+            timing=ToolCallTiming(
+                started_at=self._started_at,
+                ended_at=self._ended_at,
+                duration_ms=duration_ms,
+            ),
+            metadata=self._metadata,
+        )
+
+        self._recorder.log_event(self._run_id, "tool_call", payload.to_dict())
+
+        # Don't suppress exceptions
+        return None
+
+
+def record_tool_call(
+    recorder: Any,
+    run_id: str,
+    tool_name: str,
+    *,
+    allow_in_replay: bool = False,
+) -> Callable[[F], F]:
+    """
+    Decorator that records a function call as a tool_call event.
+
+    The decorated function's kwargs become the request payload.
+    The return value becomes the response payload (wrapped in {"result": ...}
+    if it's not already a dict).
+
+    Args:
+        recorder: RunRecorder instance
+        run_id: Current run ID
+        tool_name: Tool name (e.g., "bigquery.query", "http.request")
+        allow_in_replay: If True, allow execution during replay mode
+
+    Example::
+
+        @record_tool_call(recorder, run_id, "db.query")
+        def query_db(sql, params=None):
+            return db.execute(sql, params)
+    """
+
+    def decorator(fn: F) -> F:
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with ToolCallRecorder(
+                recorder,
+                run_id,
+                tool_name,
+                allow_in_replay=allow_in_replay,
+            ) as tc:
+                tc.set_request(
+                    {"args": list(args), "kwargs": kwargs} if args else kwargs
+                )
+                result = fn(*args, **kwargs)
+                if isinstance(result, dict):
+                    tc.set_response(result)
+                else:
+                    tc.set_response({"result": result})
+                return result
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/forkline/storage/recorder.py
+++ b/forkline/storage/recorder.py
@@ -21,7 +21,11 @@ from forkline.artifact.migrate import migrate_artifact
 from forkline.artifact.schema import (
     RunArtifact,
 )
-from forkline.core.redaction import RedactionPolicy, create_default_policy
+from forkline.core.redaction import (
+    RedactionPolicy,
+    create_default_policy,
+    load_redaction_config,
+)
 from forkline.version import (
     DEFAULT_FORKLINE_VERSION,
     DEFAULT_SCHEMA_VERSION,
@@ -205,6 +209,75 @@ class RunRecorder:
             event_id = cursor.lastrowid
 
         return event_id
+
+    @classmethod
+    def with_config(
+        cls,
+        db_path: str = "runs.db",
+        redact_config_path: Optional[str] = None,
+    ) -> "RunRecorder":
+        """
+        Create a RunRecorder with redaction policy loaded from a config file.
+
+        If no config path is provided, uses the default SAFE policy.
+
+        Args:
+            db_path: Path to SQLite database
+            redact_config_path: Path to redaction config file (YAML or JSON)
+        """
+        policy = None
+        if redact_config_path is not None:
+            config = load_redaction_config(redact_config_path)
+            policy = config.to_policy()
+        return cls(db_path=db_path, redaction_policy=policy)
+
+    def log_tool_call(
+        self,
+        run_id: str,
+        tool_name: str,
+        request: Dict[str, Any],
+        response: Optional[Dict[str, Any]] = None,
+        error: Optional[Dict[str, Any]] = None,
+        timing: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        invocation_id: Optional[str] = None,
+    ) -> int:
+        """
+        Log a tool call event with the canonical payload structure.
+
+        Convenience method that constructs a properly-structured tool_call
+        event payload and logs it. Redaction is applied at the storage boundary.
+
+        Args:
+            run_id: Run identifier
+            tool_name: Tool name (e.g., "bigquery.query", "http.request")
+            request: Request payload (will be redacted)
+            response: Response payload (will be redacted), or None
+            error: Error payload (will be redacted), or None
+            timing: Timing dict with started_at, ended_at, duration_ms
+            metadata: Optional metadata (status_code, row_count, etc.)
+            invocation_id: Stable invocation ID (auto-generated if not provided)
+
+        Returns:
+            event_id
+        """
+        if invocation_id is None:
+            invocation_id = uuid.uuid4().hex
+
+        payload: Dict[str, Any] = {
+            "tool_name": tool_name,
+            "invocation_id": invocation_id,
+            "request": request,
+            "timing": timing or {},
+        }
+        if response is not None:
+            payload["response"] = response
+        if error is not None:
+            payload["error"] = error
+        if metadata:
+            payload["metadata"] = metadata
+
+        return self.log_event(run_id, "tool_call", payload)
 
     def end_run(self, run_id: str, status: str = "success") -> None:
         """

--- a/tests/unit/test_redaction_engine.py
+++ b/tests/unit/test_redaction_engine.py
@@ -1,0 +1,519 @@
+"""
+Tests for the enhanced redaction engine.
+
+Covers:
+- Regex-based string value redaction
+- Deterministic sorted key traversal
+- Custom replacement strings
+- RedactionConfig loading from JSON
+- Config-to-policy conversion
+- Rule order stability
+- Cross-run determinism (dict construction order independence)
+- Default policy regex rules (JWT, Bearer, AWS keys)
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from forkline.core.redaction import (
+    RedactionAction,
+    RedactionConfig,
+    RedactionPolicy,
+    RedactionRule,
+    RegexRedactionRule,
+    create_default_policy,
+    load_redaction_config,
+)
+
+
+class TestRegexRedactionRule(unittest.TestCase):
+    """Test RegexRedactionRule construction and matching."""
+
+    def test_from_config(self):
+        rule = RegexRedactionRule.from_config(
+            name="jwt",
+            pattern_str=r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+            replacement="[REDACTED:jwt]",
+        )
+        self.assertEqual(rule.name, "jwt")
+        self.assertEqual(rule.replacement, "[REDACTED:jwt]")
+
+    def test_pattern_matches(self):
+        rule = RegexRedactionRule.from_config(
+            name="bearer",
+            pattern_str=r"(?i)bearer\s+[A-Za-z0-9._\-]+",
+            replacement="Bearer [REDACTED]",
+        )
+        result = rule.pattern.sub(rule.replacement, "Bearer abc123.xyz")
+        self.assertEqual(result, "Bearer [REDACTED]")
+
+
+class TestRegexRedaction(unittest.TestCase):
+    """Test regex-based string value redaction."""
+
+    def test_jwt_redaction(self):
+        policy = RedactionPolicy(
+            rules=[],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="jwt",
+                    pattern_str=r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+                    replacement="[REDACTED:jwt]",
+                ),
+            ],
+        )
+        jwt = "eyJhbGciOiJIUzI1NiJ9" ".eyJzdWIiOiIxMjM0NTY3ODkwIn0" ".abcdef123456"
+        payload = {
+            "message": f"Token is {jwt}",
+            "safe": "no jwt here",
+        }
+        redacted = policy.redact("test", payload)
+        self.assertIn("[REDACTED:jwt]", redacted["message"])
+        self.assertNotIn("eyJ", redacted["message"])
+        self.assertEqual(redacted["safe"], "no jwt here")
+
+    def test_bearer_token_redaction(self):
+        policy = RedactionPolicy(
+            rules=[],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="bearer",
+                    pattern_str=r"(?i)bearer\s+[A-Za-z0-9._\-]+",
+                    replacement="Bearer [REDACTED]",
+                ),
+            ],
+        )
+        payload = {"auth": "Bearer sk-12345.abc_def"}
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["auth"], "Bearer [REDACTED]")
+
+    def test_aws_key_redaction(self):
+        policy = RedactionPolicy(
+            rules=[],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="aws_key",
+                    pattern_str=r"AKIA[A-Z0-9]{16}",
+                    replacement="[REDACTED:aws_key]",
+                ),
+            ],
+        )
+        payload = {"credentials": "key=AKIAIOSFODNN7EXAMPLE and more text"}
+        redacted = policy.redact("test", payload)
+        self.assertIn("[REDACTED:aws_key]", redacted["credentials"])
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", redacted["credentials"])
+
+    def test_regex_applied_in_nested_structures(self):
+        policy = RedactionPolicy(
+            rules=[],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="jwt",
+                    pattern_str=r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+                    replacement="[REDACTED:jwt]",
+                ),
+            ],
+        )
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature123"
+        payload = {
+            "level1": {
+                "level2": {"token_value": f"prefix {jwt} suffix"},
+            },
+            "list_items": [f"item {jwt}", "clean item"],
+        }
+        redacted = policy.redact("test", payload)
+        self.assertNotIn("eyJ", json.dumps(redacted))
+        self.assertIn("[REDACTED:jwt]", redacted["level1"]["level2"]["token_value"])
+        self.assertIn("[REDACTED:jwt]", redacted["list_items"][0])
+        self.assertEqual(redacted["list_items"][1], "clean item")
+
+    def test_multiple_regex_rules_applied_in_order(self):
+        policy = RedactionPolicy(
+            rules=[],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="ssn",
+                    pattern_str=r"\d{3}-\d{2}-\d{4}",
+                    replacement="[REDACTED:ssn]",
+                ),
+                RegexRedactionRule.from_config(
+                    name="phone",
+                    pattern_str=r"\d{3}-\d{3}-\d{4}",
+                    replacement="[REDACTED:phone]",
+                ),
+            ],
+        )
+        payload = {
+            "ssn": "123-45-6789",
+            "phone": "555-123-4567",
+        }
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["ssn"], "[REDACTED:ssn]")
+        self.assertEqual(redacted["phone"], "[REDACTED:phone]")
+
+    def test_regex_determinism(self):
+        """Same regex rules + same input = same output."""
+        policy = RedactionPolicy(
+            rules=[],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="jwt",
+                    pattern_str=r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+                    replacement="[REDACTED:jwt]",
+                ),
+            ],
+        )
+        payload = {"token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig"}
+
+        results = [policy.redact("test", payload) for _ in range(10)]
+        for r in results[1:]:
+            self.assertEqual(results[0], r)
+
+
+class TestSortedKeyTraversal(unittest.TestCase):
+    """Test deterministic sorted key traversal in dict redaction."""
+
+    def test_sorted_traversal_produces_sorted_output(self):
+        policy = RedactionPolicy(rules=[])
+        payload = {"z_key": 1, "a_key": 2, "m_key": 3}
+        redacted = policy.redact("test", payload)
+        self.assertEqual(list(redacted.keys()), ["a_key", "m_key", "z_key"])
+
+    def test_different_construction_order_same_result(self):
+        """Dicts constructed in different order produce identical redacted output."""
+        policy = RedactionPolicy(
+            rules=[RedactionRule(action=RedactionAction.MASK, key_pattern="secret")]
+        )
+
+        payload_a = {"z": "val_z", "secret_key": "sensitive", "a": "val_a"}
+        payload_b = {"a": "val_a", "secret_key": "sensitive", "z": "val_z"}
+
+        redacted_a = policy.redact("test", payload_a)
+        redacted_b = policy.redact("test", payload_b)
+
+        self.assertEqual(redacted_a, redacted_b)
+        self.assertEqual(
+            json.dumps(redacted_a, sort_keys=True),
+            json.dumps(redacted_b, sort_keys=True),
+        )
+
+    def test_nested_sorted_traversal(self):
+        policy = RedactionPolicy(rules=[])
+        payload = {
+            "b": {"y": 1, "x": 2},
+            "a": {"z": 3, "w": 4},
+        }
+        redacted = policy.redact("test", payload)
+        self.assertEqual(list(redacted.keys()), ["a", "b"])
+        self.assertEqual(list(redacted["a"].keys()), ["w", "z"])
+        self.assertEqual(list(redacted["b"].keys()), ["x", "y"])
+
+
+class TestCustomReplacement(unittest.TestCase):
+    """Test custom replacement strings in redaction rules."""
+
+    def test_custom_replacement_in_rule(self):
+        rule = RedactionRule(
+            action=RedactionAction.MASK,
+            key_pattern="password",
+            replacement="[REDACTED:password]",
+        )
+        policy = RedactionPolicy(rules=[rule])
+        payload = {"password": "secret123"}
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["password"], "[REDACTED:password]")
+
+    def test_default_replacement(self):
+        rule = RedactionRule(action=RedactionAction.MASK, key_pattern="secret")
+        self.assertEqual(rule.replacement, "[REDACTED]")
+
+
+class TestRedactionConfig(unittest.TestCase):
+    """Test RedactionConfig and config file loading."""
+
+    def test_config_to_policy_keys(self):
+        config = RedactionConfig(
+            redact_keys=["password", "token", "api_key"],
+        )
+        policy = config.to_policy()
+        payload = {"password": "secret", "token": "abc", "safe": "ok"}
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["password"], "[REDACTED]")
+        self.assertEqual(redacted["token"], "[REDACTED]")
+        self.assertEqual(redacted["safe"], "ok")
+
+    def test_config_to_policy_paths(self):
+        config = RedactionConfig(
+            redact_paths=["headers.authorization"],
+        )
+        policy = config.to_policy()
+        payload = {
+            "headers": {"authorization": "Bearer token", "content-type": "json"},
+        }
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["headers"]["authorization"], "[REDACTED]")
+        self.assertEqual(redacted["headers"]["content-type"], "json")
+
+    def test_config_to_policy_regex(self):
+        config = RedactionConfig(
+            redact_regex=[
+                {
+                    "name": "jwt",
+                    "pattern": r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+                    "replacement": "[REDACTED:jwt]",
+                }
+            ],
+        )
+        policy = config.to_policy()
+        payload = {"data": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig"}
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["data"], "[REDACTED:jwt]")
+
+    def test_config_to_policy_combined(self):
+        config = RedactionConfig(
+            redact_keys=["api_key"],
+            redact_paths=["headers.cookie"],
+            redact_regex=[
+                {
+                    "name": "bearer",
+                    "pattern": r"(?i)bearer\s+[A-Za-z0-9._\-]+",
+                    "replacement": "Bearer [REDACTED]",
+                }
+            ],
+        )
+        policy = config.to_policy()
+        payload = {
+            "api_key": "secret",
+            "headers": {"cookie": "session=abc", "x-custom": "Bearer my-token"},
+        }
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["api_key"], "[REDACTED]")
+        self.assertEqual(redacted["headers"]["cookie"], "[REDACTED]")
+        self.assertEqual(redacted["headers"]["x-custom"], "Bearer [REDACTED]")
+
+    def test_load_config_from_json(self):
+        config_data = {
+            "fields": {
+                "redact_keys": ["password", "token"],
+                "redact_paths": ["headers.authorization"],
+                "redact_regex": [
+                    {
+                        "name": "jwt",
+                        "pattern": r"eyJ[A-Za-z0-9_-]+",
+                        "replacement": "[REDACTED:jwt]",
+                    }
+                ],
+            }
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            f.flush()
+            config_path = f.name
+
+        try:
+            config = load_redaction_config(config_path)
+            self.assertEqual(config.redact_keys, ["password", "token"])
+            self.assertEqual(config.redact_paths, ["headers.authorization"])
+            self.assertEqual(len(config.redact_regex), 1)
+            self.assertEqual(config.redact_regex[0]["name"], "jwt")
+
+            policy = config.to_policy()
+            payload = {"password": "secret", "safe": "ok"}
+            redacted = policy.redact("test", payload)
+            self.assertEqual(redacted["password"], "[REDACTED]")
+            self.assertEqual(redacted["safe"], "ok")
+        finally:
+            os.unlink(config_path)
+
+    def test_load_config_flat_format(self):
+        """Config without 'fields' wrapper also works."""
+        config_data = {
+            "redact_keys": ["secret"],
+            "redact_paths": [],
+            "redact_regex": [],
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(config_data, f)
+            f.flush()
+            config_path = f.name
+
+        try:
+            config = load_redaction_config(config_path)
+            self.assertEqual(config.redact_keys, ["secret"])
+        finally:
+            os.unlink(config_path)
+
+    def test_load_config_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            load_redaction_config("/nonexistent/path/config.json")
+
+    def test_load_config_unsupported_extension(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"not a config")
+            config_path = f.name
+        try:
+            with self.assertRaises(ValueError):
+                load_redaction_config(config_path)
+        finally:
+            os.unlink(config_path)
+
+
+class TestRuleOrderStability(unittest.TestCase):
+    """Test that rule application order is stable and deterministic."""
+
+    def test_structural_rules_first_match_wins(self):
+        policy = RedactionPolicy(
+            rules=[
+                RedactionRule(
+                    action=RedactionAction.MASK,
+                    key_pattern="token",
+                    replacement="[REDACTED:first]",
+                ),
+                RedactionRule(
+                    action=RedactionAction.MASK,
+                    key_pattern="token",
+                    replacement="[REDACTED:second]",
+                ),
+            ],
+        )
+        payload = {"token": "value"}
+        redacted = policy.redact("test", payload)
+        self.assertEqual(redacted["token"], "[REDACTED:first]")
+
+    def test_structural_before_regex(self):
+        """Structural rules (key/path match) apply before regex rules."""
+        policy = RedactionPolicy(
+            rules=[
+                RedactionRule(action=RedactionAction.MASK, key_pattern="secret"),
+            ],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="digits",
+                    pattern_str=r"\d+",
+                    replacement="[NUM]",
+                ),
+            ],
+        )
+        payload = {"secret": "value123", "safe": "text456"}
+        redacted = policy.redact("test", payload)
+        # structural rule applies first, replaces entire value
+        self.assertEqual(redacted["secret"], "[REDACTED]")
+        # regex applies to surviving string values
+        self.assertEqual(redacted["safe"], "text[NUM]")
+
+    def test_rule_order_deterministic_across_runs(self):
+        """Same rules in same order produce same results every time."""
+
+        def make_policy():
+            return RedactionPolicy(
+                rules=[
+                    RedactionRule(action=RedactionAction.MASK, key_pattern="a"),
+                    RedactionRule(action=RedactionAction.HASH, key_pattern="b"),
+                    RedactionRule(action=RedactionAction.DROP, key_pattern="c"),
+                ],
+                regex_rules=[
+                    RegexRedactionRule.from_config("r1", r"\d+", "[NUM]"),
+                ],
+            )
+
+        payload = {"a_key": "v1", "b_key": "v2", "c_key": "v3", "d_key": "123"}
+
+        results = [make_policy().redact("test", payload) for _ in range(5)]
+        for r in results[1:]:
+            self.assertEqual(results[0], r)
+
+
+class TestDefaultPolicyRegex(unittest.TestCase):
+    """Test default policy regex rules."""
+
+    def test_default_policy_redacts_jwt_in_values(self):
+        policy = create_default_policy()
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dG9rZW5fc2lnbmF0dXJl"
+        payload = {"message": f"Login token: {jwt}"}
+        redacted = policy.redact("test", payload)
+        self.assertNotIn("eyJ", redacted["message"])
+        self.assertIn("[REDACTED:jwt]", redacted["message"])
+
+    def test_default_policy_redacts_bearer_in_values(self):
+        policy = create_default_policy()
+        payload = {"log_line": "Authorization: Bearer sk-12345abcdef"}
+        redacted = policy.redact("test", payload)
+        self.assertNotIn("sk-12345abcdef", redacted["log_line"])
+
+    def test_default_policy_redacts_aws_keys(self):
+        policy = create_default_policy()
+        payload = {"debug": "Using key AKIAIOSFODNN7EXAMPLE for access"}
+        redacted = policy.redact("test", payload)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", redacted["debug"])
+        self.assertIn("[REDACTED:aws_key]", redacted["debug"])
+
+
+class TestHashDeterminism(unittest.TestCase):
+    """Test that hash action produces stable, deterministic hashes."""
+
+    def test_hash_deterministic(self):
+        policy = RedactionPolicy(
+            rules=[RedactionRule(action=RedactionAction.HASH, key_pattern="secret")]
+        )
+        payload = {"secret_key": "sensitive_value"}
+        r1 = policy.redact("test", payload)
+        r2 = policy.redact("test", payload)
+        self.assertEqual(r1["secret_key"], r2["secret_key"])
+        self.assertTrue(r1["secret_key"].startswith("hash:"))
+
+    def test_hash_of_dict_is_stable(self):
+        """Hash of a dict value uses json.dumps with sort_keys for stability."""
+        policy = RedactionPolicy(
+            rules=[RedactionRule(action=RedactionAction.HASH, key_pattern="secret")]
+        )
+        payload_a = {"secret_data": {"z": 1, "a": 2}}
+        payload_b = {"secret_data": {"a": 2, "z": 1}}
+        r_a = policy.redact("test", payload_a)
+        r_b = policy.redact("test", payload_b)
+        self.assertEqual(r_a["secret_data"], r_b["secret_data"])
+
+
+class TestRecorderWithConfig(unittest.TestCase):
+    """Test RunRecorder.with_config factory method."""
+
+    def test_with_config_loads_json(self):
+        config_data = {
+            "fields": {
+                "redact_keys": ["custom_secret"],
+                "redact_paths": [],
+                "redact_regex": [],
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "redact.json")
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
+            from forkline.storage.recorder import RunRecorder
+
+            recorder = RunRecorder.with_config(
+                db_path=os.path.join(tmpdir, "test.db"),
+                redact_config_path=config_path,
+            )
+            run_id = recorder.start_run("test.py")
+            recorder.log_event(run_id, "test", {"custom_secret": "value", "safe": "ok"})
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(events[0]["payload"]["custom_secret"], "[REDACTED]")
+            self.assertEqual(events[0]["payload"]["safe"], "ok")
+
+    def test_with_config_none_uses_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from forkline.storage.recorder import RunRecorder
+
+            recorder = RunRecorder.with_config(
+                db_path=os.path.join(tmpdir, "test.db"),
+                redact_config_path=None,
+            )
+            self.assertIsNotNone(recorder.redaction_policy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_tool_call.py
+++ b/tests/unit/test_tool_call.py
@@ -1,0 +1,607 @@
+"""
+Tests for tool call instrumentation.
+
+Covers:
+- ToolCallPayload schema and serialization
+- ToolCallRecorder context manager (capture, timing, error handling)
+- record_tool_call decorator
+- Integration with RunRecorder (storage boundary + redaction)
+- Replay mode guardrails
+- Determinism of tool call event capture
+- No raw secrets persisted (end-to-end)
+"""
+
+import json
+import tempfile
+import time
+import unittest
+
+from forkline.core.redaction import (
+    RedactionAction,
+    RedactionPolicy,
+    RedactionRule,
+    RegexRedactionRule,
+)
+from forkline.core.replay import DeterminismViolationError, replay_mode
+from forkline.core.tool_call import (
+    ToolCallPayload,
+    ToolCallRecorder,
+    ToolCallTiming,
+    record_tool_call,
+)
+from forkline.storage.recorder import RunRecorder
+
+
+class TestToolCallPayload(unittest.TestCase):
+    """Test ToolCallPayload schema and serialization."""
+
+    def test_to_dict_minimal(self):
+        payload = ToolCallPayload(
+            tool_name="http.request",
+            invocation_id="inv-001",
+            request={"url": "https://api.example.com"},
+        )
+        d = payload.to_dict()
+        self.assertEqual(d["tool_name"], "http.request")
+        self.assertEqual(d["invocation_id"], "inv-001")
+        self.assertEqual(d["request"], {"url": "https://api.example.com"})
+        self.assertNotIn("response", d)
+        self.assertNotIn("error", d)
+        self.assertIn("timing", d)
+
+    def test_to_dict_full(self):
+        payload = ToolCallPayload(
+            tool_name="db.query",
+            invocation_id="inv-002",
+            request={"sql": "SELECT 1"},
+            response={"rows": [{"id": 1}]},
+            error=None,
+            timing=ToolCallTiming(
+                started_at="2026-01-01T00:00:00Z",
+                ended_at="2026-01-01T00:00:01Z",
+                duration_ms=1000.0,
+            ),
+            metadata={"row_count": 1, "cache_hit": False},
+        )
+        d = payload.to_dict()
+        self.assertEqual(d["tool_name"], "db.query")
+        self.assertEqual(d["response"], {"rows": [{"id": 1}]})
+        self.assertEqual(d["timing"]["duration_ms"], 1000.0)
+        self.assertEqual(d["metadata"]["row_count"], 1)
+        self.assertNotIn("error", d)
+
+    def test_to_dict_with_error(self):
+        payload = ToolCallPayload(
+            tool_name="http.request",
+            invocation_id="inv-003",
+            request={"url": "https://api.example.com"},
+            error={"type": "ConnectionError", "message": "timeout"},
+        )
+        d = payload.to_dict()
+        self.assertIn("error", d)
+        self.assertEqual(d["error"]["type"], "ConnectionError")
+        self.assertNotIn("response", d)
+
+    def test_from_dict_roundtrip(self):
+        original = ToolCallPayload(
+            tool_name="file.read",
+            invocation_id="inv-004",
+            request={"path": "/tmp/test.txt"},
+            response={"content": "hello world"},
+            timing=ToolCallTiming(
+                started_at="2026-01-01T00:00:00Z",
+                ended_at="2026-01-01T00:00:00.100Z",
+                duration_ms=100.0,
+            ),
+            metadata={"bytes_read": 11},
+        )
+        d = original.to_dict()
+        reconstructed = ToolCallPayload.from_dict(d)
+        self.assertEqual(reconstructed.tool_name, original.tool_name)
+        self.assertEqual(reconstructed.invocation_id, original.invocation_id)
+        self.assertEqual(reconstructed.request, original.request)
+        self.assertEqual(reconstructed.response, original.response)
+        self.assertEqual(reconstructed.timing.duration_ms, original.timing.duration_ms)
+        self.assertEqual(reconstructed.metadata, original.metadata)
+
+    def test_from_dict_ignores_unknown_fields(self):
+        d = {
+            "tool_name": "test",
+            "invocation_id": "inv-005",
+            "request": {},
+            "future_field": "should be ignored",
+        }
+        payload = ToolCallPayload.from_dict(d)
+        self.assertEqual(payload.tool_name, "test")
+
+    def test_json_serializable(self):
+        payload = ToolCallPayload(
+            tool_name="http.request",
+            invocation_id="inv-006",
+            request={"url": "https://example.com"},
+            response={"status": 200},
+        )
+        json_str = json.dumps(payload.to_dict(), sort_keys=True)
+        parsed = json.loads(json_str)
+        self.assertEqual(parsed["tool_name"], "http.request")
+
+
+class TestToolCallRecorder(unittest.TestCase):
+    """Test ToolCallRecorder context manager."""
+
+    def test_basic_recording(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+                tc.set_request({"url": "https://api.example.com"})
+                tc.set_response({"status": 200, "body": "OK"})
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["type"], "tool_call")
+
+            payload = events[0]["payload"]
+            self.assertEqual(payload["tool_name"], "http.request")
+            self.assertEqual(payload["request"]["url"], "https://api.example.com")
+            self.assertEqual(payload["response"]["status"], 200)
+
+    def test_timing_captured(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with ToolCallRecorder(recorder, run_id, "slow.tool") as tc:
+                tc.set_request({})
+                time.sleep(0.05)
+                tc.set_response({"done": True})
+
+            events = recorder.get_events(run_id)
+            timing = events[0]["payload"]["timing"]
+            self.assertGreater(timing["duration_ms"], 40)
+            self.assertTrue(timing["started_at"])
+            self.assertTrue(timing["ended_at"])
+
+    def test_error_captured_on_exception(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with self.assertRaises(ValueError):
+                with ToolCallRecorder(recorder, run_id, "failing.tool") as tc:
+                    tc.set_request({"input": "bad"})
+                    raise ValueError("something went wrong")
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(len(events), 1)
+            payload = events[0]["payload"]
+            self.assertIn("error", payload)
+            self.assertEqual(payload["error"]["type"], "ValueError")
+            self.assertEqual(payload["error"]["message"], "something went wrong")
+            self.assertIsNone(payload.get("response"))
+
+    def test_explicit_error_overrides_exception(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with self.assertRaises(RuntimeError):
+                with ToolCallRecorder(recorder, run_id, "tool") as tc:
+                    tc.set_request({})
+                    tc.set_error({"type": "CustomError", "message": "explicit"})
+                    raise RuntimeError("implicit")
+
+            events = recorder.get_events(run_id)
+            payload = events[0]["payload"]
+            self.assertEqual(payload["error"]["type"], "CustomError")
+
+    def test_metadata_captured(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with ToolCallRecorder(recorder, run_id, "db.query") as tc:
+                tc.set_request({"sql": "SELECT 1"})
+                tc.set_response({"rows": [1]})
+                tc.set_metadata({"row_count": 1, "cache_hit": True})
+
+            events = recorder.get_events(run_id)
+            metadata = events[0]["payload"]["metadata"]
+            self.assertEqual(metadata["row_count"], 1)
+            self.assertTrue(metadata["cache_hit"])
+
+    def test_invocation_id_unique(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            for _ in range(3):
+                with ToolCallRecorder(recorder, run_id, "tool") as tc:
+                    tc.set_request({})
+                    tc.set_response({})
+
+            events = recorder.get_events(run_id)
+            ids = [e["payload"]["invocation_id"] for e in events]
+            self.assertEqual(len(set(ids)), 3)
+
+    def test_replay_mode_blocks_tool_call(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with replay_mode("test-run"):
+                with self.assertRaises(DeterminismViolationError):
+                    with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+                        tc.set_request({})
+
+    def test_allow_in_replay_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            with replay_mode("test-run"):
+                with ToolCallRecorder(
+                    recorder, run_id, "tool", allow_in_replay=True
+                ) as tc:
+                    tc.set_request({"re_exec": True})
+                    tc.set_response({"ok": True})
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(len(events), 1)
+
+
+class TestRecordToolCallDecorator(unittest.TestCase):
+    """Test the record_tool_call decorator."""
+
+    def test_decorator_captures_call(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            @record_tool_call(recorder, run_id, "math.add")
+            def add(a, b):
+                return a + b
+
+            result = add(2, 3)
+            self.assertEqual(result, 5)
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(len(events), 1)
+            payload = events[0]["payload"]
+            self.assertEqual(payload["tool_name"], "math.add")
+            self.assertEqual(payload["response"]["result"], 5)
+
+    def test_decorator_captures_dict_return(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            @record_tool_call(recorder, run_id, "api.call")
+            def api_call(endpoint):
+                return {"status": 200, "body": "ok"}
+
+            result = api_call(endpoint="/health")
+            self.assertEqual(result["status"], 200)
+
+            events = recorder.get_events(run_id)
+            payload = events[0]["payload"]
+            self.assertEqual(payload["response"]["status"], 200)
+
+    def test_decorator_captures_exception(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            @record_tool_call(recorder, run_id, "failing.tool")
+            def fail():
+                raise RuntimeError("boom")
+
+            with self.assertRaises(RuntimeError):
+                fail()
+
+            events = recorder.get_events(run_id)
+            payload = events[0]["payload"]
+            self.assertEqual(payload["error"]["type"], "RuntimeError")
+
+
+class TestToolCallRedaction(unittest.TestCase):
+    """Test that tool calls are redacted before persistence."""
+
+    def test_default_policy_redacts_tool_call_secrets(self):
+        """Sensitive fields in tool call payloads are redacted by default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(db_path=f"{tmpdir}/test.db")
+            run_id = recorder.start_run("test.py")
+
+            with ToolCallRecorder(recorder, run_id, "http.request") as tc:
+                tc.set_request(
+                    {
+                        "url": "https://api.example.com",
+                        "headers": {
+                            "Authorization": "Bearer sk-12345",
+                            "Content-Type": "application/json",
+                        },
+                        "api_key": "secret-key-123",
+                    }
+                )
+                tc.set_response({"status": 200, "body": "ok"})
+
+            events = recorder.get_events(run_id)
+            payload = events[0]["payload"]
+
+            self.assertEqual(payload["request"]["url"], "https://api.example.com")
+            self.assertEqual(payload["request"]["api_key"], "[REDACTED]")
+
+    def test_no_raw_secrets_persisted_end_to_end(self):
+        """End-to-end test: raw secrets never appear in stored events."""
+        raw_secret = "super-secret-api-key-12345"
+        raw_token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = f"{tmpdir}/test.db"
+            recorder = RunRecorder(db_path=db_path)
+            run_id = recorder.start_run("test.py")
+
+            recorder.log_tool_call(
+                run_id=run_id,
+                tool_name="http.request",
+                request={
+                    "url": "https://api.example.com",
+                    "api_key": raw_secret,
+                    "headers": {"Authorization": f"Bearer {raw_token}"},
+                },
+                response={"status": 200},
+            )
+
+            events = recorder.get_events(run_id)
+            event_json = json.dumps(events[0]["payload"])
+
+            self.assertNotIn(raw_secret, event_json)
+            self.assertNotIn(raw_token, event_json)
+
+    def test_custom_redaction_policy_on_tool_calls(self):
+        """Custom redaction policy is applied to tool call payloads."""
+        policy = RedactionPolicy(
+            rules=[
+                RedactionRule(action=RedactionAction.MASK, key_pattern="sql"),
+            ],
+            regex_rules=[
+                RegexRedactionRule.from_config(
+                    name="email",
+                    pattern_str=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+                    replacement="[REDACTED:email]",
+                ),
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(db_path=f"{tmpdir}/test.db", redaction_policy=policy)
+            run_id = recorder.start_run("test.py")
+
+            recorder.log_tool_call(
+                run_id=run_id,
+                tool_name="db.query",
+                request={
+                    "sql": "SELECT * FROM users",
+                    "note": "contact user@example.com",
+                },
+                response={"rows": [{"name": "Alice", "email": "alice@corp.com"}]},
+            )
+
+            events = recorder.get_events(run_id)
+            payload = events[0]["payload"]
+
+            self.assertEqual(payload["request"]["sql"], "[REDACTED]")
+            self.assertIn("[REDACTED:email]", payload["request"]["note"])
+            self.assertIn("[REDACTED:email]", payload["response"]["rows"][0]["email"])
+
+
+class TestToolCallEventOrdering(unittest.TestCase):
+    """Test that tool call events maintain strict ordering."""
+
+    def test_event_ordering_preserved(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            for i in range(5):
+                with ToolCallRecorder(recorder, run_id, f"tool.{i}") as tc:
+                    tc.set_request({"index": i})
+                    tc.set_response({"result": i * 2})
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(len(events), 5)
+
+            for i, event in enumerate(events):
+                self.assertEqual(event["payload"]["tool_name"], f"tool.{i}")
+                self.assertEqual(event["payload"]["request"]["index"], i)
+
+            event_ids = [e["event_id"] for e in events]
+            self.assertEqual(event_ids, sorted(event_ids))
+
+    def test_tool_calls_in_json_export(self):
+        """Tool call events survive JSON export/import cycle."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            recorder.log_tool_call(
+                run_id=run_id,
+                tool_name="http.get",
+                request={"url": "https://example.com"},
+                response={"status": 200},
+                timing={
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "ended_at": "2026-01-01T00:00:01Z",
+                    "duration_ms": 1000,
+                },
+                metadata={"bytes_read": 1024},
+            )
+
+            recorder.end_run(run_id)
+
+            json_str = recorder.export_artifact_json(run_id)
+            self.assertIsNotNone(json_str)
+
+            from forkline.artifact.schema import RunArtifact
+
+            artifact = RunArtifact.from_json(json_str)
+            tool_events = [e for e in artifact.events if e.type == "tool_call"]
+            self.assertEqual(len(tool_events), 1)
+
+            payload = tool_events[0].payload
+            self.assertEqual(payload["tool_name"], "http.get")
+            self.assertEqual(payload["response"]["status"], 200)
+            self.assertEqual(payload["metadata"]["bytes_read"], 1024)
+
+
+class TestLogToolCallConvenience(unittest.TestCase):
+    """Test RunRecorder.log_tool_call convenience method."""
+
+    def test_log_tool_call_basic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            event_id = recorder.log_tool_call(
+                run_id=run_id,
+                tool_name="file.read",
+                request={"path": "/tmp/data.txt"},
+                response={"content": "hello"},
+            )
+
+            self.assertIsNotNone(event_id)
+            events = recorder.get_events(run_id)
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["type"], "tool_call")
+            self.assertEqual(events[0]["payload"]["tool_name"], "file.read")
+
+    def test_log_tool_call_auto_invocation_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            recorder.log_tool_call(run_id, "tool.a", request={})
+            recorder.log_tool_call(run_id, "tool.b", request={})
+
+            events = recorder.get_events(run_id)
+            id_a = events[0]["payload"]["invocation_id"]
+            id_b = events[1]["payload"]["invocation_id"]
+            self.assertNotEqual(id_a, id_b)
+            self.assertTrue(len(id_a) > 0)
+
+    def test_log_tool_call_explicit_invocation_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            recorder.log_tool_call(
+                run_id, "tool", request={}, invocation_id="stable-id-001"
+            )
+
+            events = recorder.get_events(run_id)
+            self.assertEqual(events[0]["payload"]["invocation_id"], "stable-id-001")
+
+    def test_log_tool_call_with_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                db_path=f"{tmpdir}/test.db",
+                redaction_policy=RedactionPolicy(rules=[]),
+            )
+            run_id = recorder.start_run("test.py")
+
+            recorder.log_tool_call(
+                run_id,
+                "http.request",
+                request={"url": "https://example.com"},
+                error={"type": "Timeout", "message": "30s exceeded"},
+            )
+
+            events = recorder.get_events(run_id)
+            payload = events[0]["payload"]
+            self.assertIn("error", payload)
+            self.assertEqual(payload["error"]["type"], "Timeout")
+            self.assertNotIn("response", payload)
+
+
+class TestToolCallDeterminism(unittest.TestCase):
+    """Test that tool call event capture is deterministic."""
+
+    def test_same_input_same_output(self):
+        """Same tool call payload produces identical stored events."""
+        results = []
+        for _ in range(3):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                recorder = RunRecorder(db_path=f"{tmpdir}/test.db")
+                run_id = recorder.start_run("test.py", run_id="fixed-run-id")
+
+                recorder.log_tool_call(
+                    run_id=run_id,
+                    tool_name="http.get",
+                    request={
+                        "url": "https://api.example.com",
+                        "api_key": "secret-123",
+                        "headers": {"Authorization": "Bearer token"},
+                    },
+                    response={"status": 200, "body": "ok"},
+                    invocation_id="fixed-inv-id",
+                )
+
+                events = recorder.get_events(run_id)
+                results.append(events[0]["payload"])
+
+        self.assertEqual(results[0], results[1])
+        self.assertEqual(results[1], results[2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Tool Invocation Recording + Deterministic Redaction

Record tool invocations (DB queries, APIs, file ops) as first-class events in the run artifact, with configurable, deterministic redaction so sensitive data is never persisted.

### What changed

**Tool call event schema** (`forkline/core/tool_call.py` — new)
- `ToolCallPayload` dataclass: canonical `tool_call` event with `tool_name`, `invocation_id`, `request`, `response`, `error`, `timing` (started_at / ended_at / duration_ms), and extensible `metadata` (status_code, row_count, cache_hit, etc.)
- Single-event model (Option 1): one event captures the full request+response lifecycle
- `ToolCallRecorder` context manager: auto-captures timing, records errors on exception, enforces replay mode guardrails
- `record_tool_call` decorator: wraps existing functions with zero-effort recording
- `RunRecorder.log_tool_call()` convenience method for manual construction

**Enhanced redaction engine** (`forkline/core/redaction.py`)
- **Regex-based value redaction**: `RegexRedactionRule` matches string values (JWTs, Bearer tokens, AWS keys) in addition to existing key/path matching
- **Sorted dict traversal**: keys are iterated in sorted order for cross-run determinism regardless of dict construction order
- **Custom replacement strings**: rules can specify `"[REDACTED:rule_name]"` instead of generic `"[REDACTED]"`
- **Stable hashing**: `_hash_value()` now uses `json.dumps(sort_keys=True)` for deterministic dict hashing
- **Config loading**: `RedactionConfig` + `load_redaction_config()` for YAML/JSON config files
- Default policy expanded: 18 structural rules + 3 regex rules (jwt, bearer, aws_key)

**CLI wiring** (`forkline/cli/__init__.py`)
- `--redact-config` flag on `forkline run` to load custom redaction config
- Config path passed to child processes via `FORKLINE_REDACT_CONFIG` env var
- `RunRecorder.with_config()` factory method for config-file-driven setup

**Exports** (`forkline/__init__.py`, `forkline/core/__init__.py`)
- All new types exported: `ToolCallPayload`, `ToolCallRecorder`, `ToolCallTiming`, `record_tool_call`, `RedactionConfig`, `RegexRedactionRule`, `load_redaction_config`

### Tests (58 new, 316 total — all pass)

`tests/unit/test_tool_call.py` (27 tests):
- Payload schema serialization + roundtrip
- Context manager: timing, error capture, metadata, unique invocation IDs
- Decorator: captures calls, dict returns, exceptions
- Redaction integration: default policy redacts secrets, custom policy, end-to-end "no raw secrets persisted"
- Event ordering preserved across multiple tool calls
- JSON export/import roundtrip
- Replay mode guardrails (blocks live calls, allows re-exec mode)
- Determinism: same input + same rules = identical stored events

`tests/unit/test_redaction_engine.py` (31 tests):
- Regex rules: JWT, Bearer, AWS key, nested structures, multiple rules in order
- Sorted key traversal: sorted output, different construction order → same result
- Custom replacement strings
- `RedactionConfig`: keys, paths, regex, combined, load from JSON, flat format
- Rule order stability: first match wins, structural before regex, deterministic across runs
- Default policy regex: JWTs in values, Bearer in values, AWS keys
- Hash determinism: stable across runs, dict order independent
- `RunRecorder.with_config()`: loads JSON config, falls back to default

### Docs

- `docs/tool_visibility.md`: tool_call event schema, recording APIs (context manager, decorator, convenience method), replay integration, event ordering
- `docs/redaction.md`: matching strategies, rule application order, config file format (YAML + JSON), default policy reference table, determinism guarantees, redaction pipeline diagram

### Examples

**`examples/tool_call_basic.py`** — Three recording APIs in one file

```python
# Context manager — full control
with ToolCallRecorder(recorder, run_id, "http.get") as tc:
    tc.set_request({"url": "https://api.example.com/users"})
    response = requests.get(...)
    tc.set_response({"status": 200, "count": 42})
    tc.set_metadata({"bytes_read": 2048})

# Decorator — zero-effort wrapping
@record_tool_call(recorder, run_id, "math.multiply")
def multiply(a, b):
    return a * b

# Convenience method — manual construction
recorder.log_tool_call(
    run_id=run_id,
    tool_name="file.read",
    request={"path": "/etc/hostname"},
    response={"content": "myhost"},
)
```

**`examples/tool_call_production.py`** — Realistic agentic workflow

Simulates an agent that chains 5 tool calls end-to-end with production-grade redaction:

1. **LLM planning call** (`llm.chat`) — sends API key, receives SQL
2. **Database query** (`postgres.query`) — connection string with embedded password
3. **HTTP webhook** (`http.post`) — Bearer JWT, cookies, API key in headers
4. **File write** (`file.write`) — via `@record_tool_call` decorator
5. **Failing upstream call** (`http.get`) — error captured, 3 retries recorded

Shows:
- Default policy auto-redacts `Authorization`, `Cookie`, `X-Api-Key`, `api_key`
- Custom regex rule catches `://user:password@host` in connection strings
- JWT tokens in string values are replaced with `[REDACTED:jwt]`
- Error events capture exception type + message
- Security verification confirms zero secrets in stored JSON
- JSON export produces portable 6KB artifact with 5 tool_call events

Output:

```
STORED EVENTS (after redaction)

Event 0: llm.chat                      23.6ms  [ok]
Event 1: postgres.query                15.8ms  [ok]
Event 2: http.post                     12.5ms  [ok]
Event 3: file.write                     6.3ms  [ok]
Event 4: http.get                      10.0ms  [error]

--- Security verification ---

No secrets leaked to storage.
JWT tokens in storage: No
```

### Config file format

```yaml
fields:
  redact_keys:
    - password
    - token
    - api_key
  redact_paths:
    - "tool.request.headers.Authorization"
  redact_regex:
    - name: jwt
      pattern: "eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"
      replacement: "[REDACTED:jwt]"
```

### Acceptance criteria

- [x] Tool calls captured in run artifacts as `tool_call` events (SQLite + JSON)
- [x] Sensitive fields redacted via configurable rules (key, path, regex)
- [x] Redaction is deterministic and stable across runs (sorted traversal, stable rule order)
- [x] Default safe redaction exists and is documented (18 key rules + 3 regex rules)
- [x] Tests cover determinism + tool capture + replay behavior (58 new tests)
- [x] Docs explain the tool_call schema and redaction contract
- [x] No raw secrets ever touch disk (enforced at storage boundary)
- [x] Zero new dependencies (YAML support optional via `pyyaml`)
