### PR TITLE
CI Offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Forkline is built to tell you **where**, **when**, and **why**.
 Forkline allows you to:
 
 - **Record** an agent run as a deterministic, local artifact
-- **Replay** that run without re-invoking the LLM ✅
-- **Diff** two runs and detect the **first point of divergence** ✅
+- **Replay** that run without re-invoking the LLM
+- **Diff** two runs and detect the **first point of divergence**
 - **Capture tool calls** safely with deterministic redaction
-- **Use agent workflows in CI** without network calls or flakiness
+- **Gate CI builds on behavioral identity** — no network, no flake, no ambiguity
 
 This turns agent behavior into something you can reason about like code.
 
@@ -117,6 +117,10 @@ forkline diff <run_id_a> <run_id_b> --format json
 # Use a custom database path
 forkline run --db myproject.db examples/minimal.py
 forkline list --db myproject.db
+
+# CI integration (see "CI Integration" below)
+forkline ci record --entrypoint examples/my_flow.py --out baseline.run.json
+forkline ci check --entrypoint examples/my_flow.py --expected baseline.run.json
 ```
 
 ### Example: catching LLM nondeterminism with Ollama Qwen3
@@ -196,6 +200,89 @@ See [`QUICKSTART_RECORDING_V0.md`](docs/QUICKSTART_RECORDING_V0.md) for recordin
 
 ---
 
+## CI Integration
+
+Forkline ships with a dedicated CI layer that turns agent behavior into a build gate. If behavior changes, the build fails — deterministically, offline, with a clear diff.
+
+### Record a baseline, check it in CI
+
+```bash
+# Record a baseline artifact (local dev)
+forkline ci record --entrypoint examples/my_flow.py --out tests/testdata/my_flow.run.json
+
+# Commit it to version control
+git add tests/testdata/my_flow.run.json
+
+# In CI: check that behavior hasn't changed
+forkline ci check --entrypoint examples/my_flow.py --expected tests/testdata/my_flow.run.json
+# Exit 0 = identical behavior, Exit 1 = behavior changed
+```
+
+### CI commands
+
+```bash
+# Record a normalized, committable artifact
+forkline ci record --entrypoint <script> --out <path> [--offline]
+
+# Validate an artifact's schema and structure
+forkline ci replay --artifact <path> [--strict]
+
+# Diff two artifacts (exit 1 on divergence)
+forkline ci diff --expected <path> --actual <path> [--format json|text]
+
+# All-in-one: record actual, diff against expected
+forkline ci check --entrypoint <script> --expected <path> [--offline]
+
+# Normalize an artifact for stable diffs
+forkline ci normalize <artifact> [--out <path>]
+```
+
+### Offline mode
+
+CI runs enforce a hard no-network guarantee. When `--offline` is set (or `FORKLINE_OFFLINE=1`), any network access raises `ForklineOfflineError` immediately — no hangs, no timeouts, deterministic failure.
+
+### Exit codes
+
+Forkline CI uses a strict, stable exit code contract:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success, no diff |
+| `1` | Diff detected (fail the build) |
+| `2` | Usage/config error |
+| `3` | Replay failed |
+| `4` | Offline violation |
+| `5` | Artifact/schema error |
+| `6` | Internal error |
+
+### Python test helper
+
+```python
+from forkline.testing import assert_no_diff
+
+def test_my_flow():
+    assert_no_diff(
+        entrypoint="examples/my_flow.py",
+        expected_artifact="tests/testdata/my_flow.run.json",
+        offline=True,
+    )
+```
+
+### GitHub Actions
+
+```yaml
+- name: Check for behavioral diffs
+  run: |
+    forkline ci check \
+      --entrypoint examples/my_flow.py \
+      --expected tests/testdata/my_flow.run.json \
+      --offline
+```
+
+For the full CI guide — artifact normalization, re-recording baselines, repo layout, and more — see [`docs/ci.md`](docs/ci.md).
+
+---
+
 ## Artifact Stability Guarantee
 
 Forkline guarantees replay compatibility across minor versions. Breaking changes require a major version increment and migration support.
@@ -271,8 +358,8 @@ They live in terminals, CI pipelines, local machines, and code reviews — not d
 CLI commands are composable, automatable, and repeatable.
 
 This makes Forkline usable in:
-- CI pipelines
-- test suites
+- CI pipelines (`forkline ci check` gates merges on behavioral identity)
+- test suites (`assert_no_diff` for snapshot-style testing)
 - local debugging loops
 - regression checks
 
@@ -437,7 +524,7 @@ The v0 series focuses on **correctness and determinism**, not polish.
 2. ✅ Offline replay engine  
 3. ✅ First-divergence diffing  
 4. ✅ CLI (`run`, `list`, `replay`, `diff`)  
-5. CI-friendly deterministic mode  
+5. ✅ CI integration (`ci record`, `ci replay`, `ci diff`, `ci check`, offline enforcement, exit codes)  
 
 The canonical roadmap and design contract live here:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,257 @@
+# Forkline CI Integration
+
+Deterministic, offline, build-failing diffs for CI/CD pipelines.
+
+Forkline CI lets you gate merges on **behavioral identity**: if an agent's output changes, your build fails. No flaky tests, no network dependencies, no non-determinism.
+
+## Quick Start
+
+```bash
+# 1. Record a baseline (local dev)
+forkline ci record --entrypoint examples/my_flow.py --out tests/testdata/my_flow.run.json
+
+# 2. Commit the artifact to version control
+git add tests/testdata/my_flow.run.json
+
+# 3. In CI, check that behavior hasn't changed
+forkline ci check --entrypoint examples/my_flow.py --expected tests/testdata/my_flow.run.json
+# Exit code 0 = no diff, 1 = behavior changed
+```
+
+## Commands
+
+### `forkline ci record`
+
+Record a baseline artifact to a JSON file.
+
+```bash
+forkline ci record --entrypoint <script> --out <path> [--offline]
+```
+
+- Runs the script under Forkline tracing
+- Produces a **normalized** artifact (timestamps stripped, metadata cleaned)
+- Suitable for committing to version control or storing in `testdata/`
+
+### `forkline ci replay`
+
+Validate a recorded artifact offline.
+
+```bash
+forkline ci replay --artifact <path> [--strict]
+```
+
+- Loads and validates the artifact schema
+- With `--strict`: verifies all events have complete payloads
+- Runs with zero network access
+
+### `forkline ci diff`
+
+Compare two artifact files.
+
+```bash
+forkline ci diff --expected <path> --actual <path> [--format json|text] [--fail-on any|first-divergence|semantic]
+```
+
+- Normalizes both artifacts before comparison (timestamps, metadata)
+- Returns exit code 1 on any behavioral diff
+- JSON mode produces machine-readable output with:
+  - First divergent event index
+  - Event type
+  - Payload diff summary
+  - Suggested fix (re-record baseline)
+
+### `forkline ci check`
+
+All-in-one: record actual, diff against expected.
+
+```bash
+forkline ci check --entrypoint <script> --expected <path> [--offline] [--format json|text]
+```
+
+- Internally records into a temp directory
+- Diffs against the expected artifact
+- Default: `--offline` is **on** (blocks all network access)
+
+### `forkline ci normalize`
+
+Normalize an artifact for stable diffs.
+
+```bash
+forkline ci normalize <artifact> [--out <path>]
+```
+
+- Strips timestamps, platform metadata
+- Sorts events by event_id
+- Overwrites in place unless `--out` is specified
+
+## Exit Codes
+
+Forkline CI uses a strict exit code contract. These values are stable across releases.
+
+| Code | Meaning | CI Action |
+|------|---------|-----------|
+| `0` | Success, no diff / replay ok | Pass |
+| `1` | Diff detected (policy violation) | **Fail build** |
+| `2` | Usage/config error (bad args, missing file) | Fix config |
+| `3` | Replay failed (runtime exception) | Fix script |
+| `4` | Offline violation (network attempted) | Fix test isolation |
+| `5` | Artifact/schema error (cannot parse) | Re-record or fix schema |
+| `6` | Internal error (unexpected bug) | Report issue |
+
+## Offline Mode
+
+Forkline CI enforces a **hard no-network guarantee** when `--offline` is set (or `FORKLINE_OFFLINE=1`).
+
+When active:
+- `socket.connect()`, `socket.create_connection()`, and `socket.getaddrinfo()` are monkeypatched
+- Any network attempt raises `ForklineOfflineError` immediately (no hang, no timeout)
+- The error message is deterministic and includes the operation that was attempted
+
+```bash
+# Via flag
+forkline ci check --entrypoint flow.py --expected baseline.json --offline
+
+# Via environment variable
+FORKLINE_OFFLINE=1 forkline ci check --entrypoint flow.py --expected baseline.json
+```
+
+## Artifact Normalization
+
+CI artifacts are normalized to remove unstable fields:
+
+**Normalized by default:**
+- All timestamp fields (`ts`, `started_at`, `ended_at`, `created_at`) → `2000-01-01T00:00:00+00:00`
+- Platform metadata (`python_version`, `platform`, `cwd`) → removed
+- Events sorted by `event_id`
+
+**Preserved:**
+- Event types and payloads (the behavioral data)
+- Schema version
+- Entrypoint path
+
+This means artifacts recorded on different machines, at different times, produce **identical diffs** when behavior is the same.
+
+## Recommended Repo Layout
+
+```
+my-repo/
+├── examples/
+│   └── my_flow.py              # Your agentic workflow
+├── tests/
+│   ├── testdata/
+│   │   └── my_flow.run.json    # Committed baseline artifact
+│   └── test_flows.py           # Python tests using assert_no_diff
+├── .github/
+│   └── workflows/
+│       └── ci.yml              # GitHub Actions workflow
+└── pyproject.toml
+```
+
+## Re-recording Baselines
+
+When you intentionally change behavior:
+
+```bash
+# Re-record the baseline
+forkline ci record --entrypoint examples/my_flow.py --out tests/testdata/my_flow.run.json
+
+# Verify it replays cleanly
+forkline ci replay --artifact tests/testdata/my_flow.run.json
+
+# Commit the updated baseline
+git add tests/testdata/my_flow.run.json
+git commit -m "Update baseline: my_flow now returns improved results"
+```
+
+## Python Test Helper
+
+For integration with pytest or unittest:
+
+```python
+from forkline.testing import assert_no_diff
+
+def test_my_flow():
+    assert_no_diff(
+        entrypoint="examples/my_flow.py",
+        expected_artifact="tests/testdata/my_flow.run.json",
+        offline=True,
+    )
+```
+
+On diff, raises `ArtifactDiffError` with:
+- First divergent event index
+- Expected vs actual payloads
+- Suggested re-record command
+
+## GitHub Actions Example
+
+```yaml
+name: Forkline CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  behavioral-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e .
+
+      - name: Validate baselines
+        run: |
+          forkline ci replay --artifact tests/testdata/my_flow.run.json --strict
+
+      - name: Check for behavioral diffs
+        run: |
+          forkline ci check \
+            --entrypoint examples/my_flow.py \
+            --expected tests/testdata/my_flow.run.json \
+            --offline \
+            --format text
+
+      # Or run multiple checks
+      - name: Check all flows
+        run: |
+          for baseline in tests/testdata/*.run.json; do
+            script="examples/$(basename "$baseline" .run.json).py"
+            echo "Checking $script against $baseline"
+            forkline ci check --entrypoint "$script" --expected "$baseline" --offline
+          done
+```
+
+## Programmatic Usage
+
+```python
+from forkline.ci.commands import ci_record, ci_diff, ci_check
+from forkline.ci.exitcodes import EXIT_SUCCESS, EXIT_DIFF_DETECTED
+
+# Record
+code = ci_record("my_flow.py", "baseline.run.json", offline=True)
+assert code == EXIT_SUCCESS
+
+# Diff
+code = ci_diff("baseline.run.json", "actual.run.json", output_format="json")
+if code == EXIT_DIFF_DETECTED:
+    print("Behavior changed!")
+
+# Check (record + diff in one call)
+code = ci_check("my_flow.py", "baseline.run.json", offline=True)
+assert code == EXIT_SUCCESS
+```
+
+## Design Principles
+
+1. **Determinism over convenience** — same input always produces same output
+2. **Strict by default** — CI should fail on any behavioral change unless explicitly accepted
+3. **Offline first** — no network dependencies in CI
+4. **Fast** — normalization and diffing are pure compute, no I/O beyond reading artifacts
+5. **Zero dependencies** — uses only Python stdlib
+6. **Meaningful exit codes** — automation-friendly, no ambiguity

--- a/examples/ci_check_gate.py
+++ b/examples/ci_check_gate.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+CI example: Build gating with `ci check`.
+
+Demonstrates the all-in-one CI command that records actual behavior
+and diffs it against an expected baseline in a single call.
+
+This is the command you'd put in your CI pipeline:
+    forkline ci check --entrypoint my_flow.py --expected baseline.run.json
+
+Here we show the full lifecycle:
+1. Record a baseline
+2. ci_check passes when behavior is unchanged
+3. ci_check fails (exit 1) when behavior changes
+
+No external dependencies. No network calls.
+
+Run:
+    python examples/ci_check_gate.py
+"""
+
+import os
+import sys
+import tempfile
+import textwrap
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from forkline.ci.commands import ci_check, ci_record
+from forkline.ci.exitcodes import EXIT_DIFF_DETECTED, EXIT_SUCCESS
+
+_INSERT = "INSERT INTO events" " (run_id, ts, type, payload)" " VALUES (?, ?, ?, ?)"
+
+
+def _write_agent(path: str, tool: str, chunks: int, summary: str) -> None:
+    """Write a script that logs input, tool_call, and output."""
+    with open(path, "w") as f:
+        f.write(
+            textwrap.dedent(
+                f"""\
+            import os, json, sqlite3
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            rid = os.environ.get("FORKLINE_RUN_ID", "")
+            SQL = "{_INSERT}"
+            if db and rid:
+                c = sqlite3.connect(db)
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:00+00:00",
+                    "input",
+                    json.dumps({{"query": "summarize document"}}),
+                ))
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:00+00:00",
+                    "tool_call",
+                    json.dumps({{"tool": "{tool}", "chunks": {chunks}}}),
+                ))
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:01+00:00",
+                    "output",
+                    json.dumps({{"summary": "{summary}"}}),
+                ))
+                c.commit()
+                c.close()
+        """
+            )
+        )
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Forkline CI: Build Gate with ci_check")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        script = os.path.join(tmpdir, "agent.py")
+        baseline = os.path.join(tmpdir, "baseline.run.json")
+
+        # Step 1: Record baseline
+        print("\n1. Recording baseline...")
+        _write_agent(
+            script,
+            tool="retriever",
+            chunks=3,
+            summary="The document discusses X, Y, Z.",
+        )
+        code = ci_record(script, baseline, offline=False)
+        assert code == EXIT_SUCCESS
+        print("   Baseline saved.")
+
+        # Step 2: Check with same script — should pass
+        print("\n2. Running ci_check (same behavior)...")
+        code = ci_check(script, baseline, offline=False)
+        print(f"   Exit code: {code}")
+        assert code == EXIT_SUCCESS
+        print("   BUILD PASS")
+
+        # Step 3: Change the script behavior
+        print("\n3. Modifying agent behavior...")
+        _write_agent(
+            script,
+            tool="retriever_v2",
+            chunks=5,
+            summary="The document covers A, B, C, D.",
+        )
+
+        # Step 4: Check again — should fail
+        print("\n4. Running ci_check (changed behavior)...")
+        code = ci_check(script, baseline, offline=False, output_format="text")
+        print(f"   Exit code: {code}")
+        assert code == EXIT_DIFF_DETECTED
+        print("   BUILD FAIL — behavioral diff detected")
+
+    print("\n" + "=" * 60)
+    print("Build gate demo complete.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ci_offline_enforcement.py
+++ b/examples/ci_offline_enforcement.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+CI example: Offline mode enforcement.
+
+Demonstrates Forkline's hard no-network guarantee:
+1. Normal code can make network calls
+2. Inside offline_context(), network calls fail immediately
+3. The error is deterministic — same message every time
+4. Normal access is restored after the context exits
+
+No external dependencies. No actual network calls succeed.
+
+Run:
+    python examples/ci_offline_enforcement.py
+"""
+
+import os
+import socket
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from forkline.ci.offline import (
+    ForklineOfflineError,
+    is_offline_mode,
+    offline_context,
+)
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Forkline CI: Offline Mode Enforcement")
+    print("=" * 60)
+
+    # Step 1: Outside offline mode — network functions are available
+    print("\n1. Outside offline mode:")
+    print(f"   is_offline_mode() = {is_offline_mode()}")
+    print("   socket.getaddrinfo is available (not blocked)")
+
+    # Step 2: Enter offline mode
+    print("\n2. Entering offline_context()...")
+    with offline_context():
+        print(f"   is_offline_mode() = {is_offline_mode()}")
+
+        # Try socket.connect
+        print("\n3. Attempting socket.connect('example.com', 80)...")
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect(("example.com", 80))
+            print("   ERROR: Should not reach here!")
+        except ForklineOfflineError as e:
+            print(f"   Blocked: {e}")
+
+        # Try socket.create_connection
+        print("\n4. Attempting socket.create_connection(('example.com', 443))...")
+        try:
+            socket.create_connection(("example.com", 443))
+            print("   ERROR: Should not reach here!")
+        except ForklineOfflineError as e:
+            print(f"   Blocked: {e}")
+
+        # Try DNS resolution
+        print("\n5. Attempting socket.getaddrinfo('example.com', 80)...")
+        try:
+            socket.getaddrinfo("example.com", 80)
+            print("   ERROR: Should not reach here!")
+        except ForklineOfflineError as e:
+            print(f"   Blocked: {e}")
+
+        # Demonstrate determinism
+        print("\n6. Verifying error determinism...")
+        errors = []
+        for _ in range(3):
+            try:
+                socket.create_connection(("api.openai.com", 443))
+            except ForklineOfflineError as e:
+                errors.append(str(e))
+        assert len(set(errors)) == 1, "Errors should be identical"
+        print("   All 3 errors identical: True")
+
+    # Step 3: After context — network restored
+    print("\n7. After offline_context():")
+    print(f"   is_offline_mode() = {is_offline_mode()}")
+    print("   Network functions restored.")
+
+    print("\n" + "=" * 60)
+    print("Offline enforcement demo complete.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ci_record_and_diff.py
+++ b/examples/ci_record_and_diff.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+CI example: Record a baseline, then diff against a changed version.
+
+Demonstrates the core CI workflow:
+1. Record a baseline artifact from a deterministic script
+2. Diff two artifacts to confirm identical behavior
+3. Introduce a behavior change
+4. Diff again to see the change caught with exit code 1
+
+No external dependencies. No network calls.
+
+Run:
+    python examples/ci_record_and_diff.py
+"""
+
+import os
+import sys
+import tempfile
+import textwrap
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from forkline.ci.commands import ci_diff, ci_record
+from forkline.ci.exitcodes import EXIT_DIFF_DETECTED, EXIT_SUCCESS
+
+_INSERT = "INSERT INTO events" " (run_id, ts, type, payload)" " VALUES (?, ?, ?, ?)"
+
+
+def _write_flow(path: str, answer: str, extra: str = "") -> None:
+    """Write a small flow script that logs input + output events."""
+    with open(path, "w") as f:
+        f.write(
+            textwrap.dedent(
+                f"""\
+            import os, json, sqlite3
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            rid = os.environ.get("FORKLINE_RUN_ID", "")
+            SQL = "{_INSERT}"
+            if db and rid:
+                c = sqlite3.connect(db)
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:00+00:00",
+                    "input",
+                    json.dumps({{"prompt": "What is 2+2?"}}),
+                ))
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:01+00:00",
+                    "output",
+                    json.dumps({{"answer": "{answer}"{extra}}}),
+                ))
+                c.commit()
+                c.close()
+        """
+            )
+        )
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Forkline CI: Record and Diff")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        v1 = os.path.join(tmpdir, "flow_v1.py")
+        v2 = os.path.join(tmpdir, "flow_v2.py")
+        _write_flow(v1, answer="4")
+        _write_flow(v2, answer="5", extra=', "note": "wrong!"')
+
+        baseline = os.path.join(tmpdir, "baseline.run.json")
+        actual_same = os.path.join(tmpdir, "actual_same.run.json")
+        actual_changed = os.path.join(tmpdir, "actual_changed.run.json")
+
+        # Step 1: Record baseline
+        print("\n1. Recording baseline from v1...")
+        code = ci_record(v1, baseline)
+        assert code == EXIT_SUCCESS, f"Expected 0, got {code}"
+        print("   Baseline recorded.")
+
+        # Step 2: Record v1 again — should be identical
+        print("\n2. Recording v1 again...")
+        code = ci_record(v1, actual_same)
+        assert code == EXIT_SUCCESS
+
+        # Step 3: Diff baseline vs same — should pass
+        print("\n3. Diffing baseline vs v1 (same behavior)...")
+        code = ci_diff(baseline, actual_same)
+        assert code == EXIT_SUCCESS, f"Expected 0, got {code}"
+        print("   No differences. Exit code: 0")
+
+        # Step 4: Record v2 — changed behavior
+        print("\n4. Recording v2 (changed behavior)...")
+        code = ci_record(v2, actual_changed)
+        assert code == EXIT_SUCCESS
+
+        # Step 5: Diff baseline vs changed — should fail
+        print("\n5. Diffing baseline vs v2 (changed behavior)...")
+        code = ci_diff(baseline, actual_changed, output_format="text")
+        assert code == EXIT_DIFF_DETECTED, f"Expected 1, got {code}"
+        print(f"   Exit code: {code} (build would fail)")
+
+        # Step 6: Show JSON diff
+        print("\n6. JSON diff output:")
+        ci_diff(baseline, actual_changed, output_format="json")
+
+    print("\n" + "=" * 60)
+    print("CI workflow complete.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ci_test_helper.py
+++ b/examples/ci_test_helper.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+CI example: Python test helper (assert_no_diff).
+
+Demonstrates how to use Forkline's test helper for snapshot-style
+testing of agentic workflows in pytest or unittest.
+
+The helper:
+1. Runs the entrypoint in a temp directory
+2. Records and normalizes the artifact
+3. Diffs against the expected baseline
+4. Raises ArtifactDiffError with a clean diff snippet on failure
+
+Run:
+    python examples/ci_test_helper.py
+"""
+
+import os
+import sys
+import tempfile
+import textwrap
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from forkline.ci.commands import ci_record
+from forkline.ci.exitcodes import EXIT_SUCCESS
+from forkline.testing import ArtifactDiffError, assert_no_diff
+
+_INSERT = "INSERT INTO events" " (run_id, ts, type, payload)" " VALUES (?, ?, ?, ?)"
+
+
+def _write_qa_flow(path: str, answer: str) -> None:
+    """Write a script that logs a Q&A exchange."""
+    with open(path, "w") as f:
+        f.write(
+            textwrap.dedent(
+                f"""\
+            import os, json, sqlite3
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            rid = os.environ.get("FORKLINE_RUN_ID", "")
+            SQL = "{_INSERT}"
+            if db and rid:
+                c = sqlite3.connect(db)
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:00+00:00",
+                    "input",
+                    json.dumps({{"question": "Capital of France?"}}),
+                ))
+                c.execute(SQL, (
+                    rid, "2026-01-01T00:00:01+00:00",
+                    "output",
+                    json.dumps({{"answer": "{answer}"}}),
+                ))
+                c.commit()
+                c.close()
+        """
+            )
+        )
+
+
+def main() -> None:
+    print("=" * 60)
+    print("Forkline CI: Python Test Helper (assert_no_diff)")
+    print("=" * 60)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        script = os.path.join(tmpdir, "my_flow.py")
+        baseline = os.path.join(tmpdir, "baseline.run.json")
+
+        # Record the baseline
+        print("\n1. Recording baseline...")
+        _write_qa_flow(script, answer="Paris")
+        code = ci_record(script, baseline, offline=False)
+        assert code == EXIT_SUCCESS
+        print(f"   Saved: {baseline}")
+
+        # Passing test
+        print("\n2. assert_no_diff (same behavior)...")
+        assert_no_diff(
+            entrypoint=script,
+            expected_artifact=baseline,
+            offline=False,
+        )
+        print("   PASSED — no behavioral diff")
+
+        # Change the script
+        print("\n3. Modifying script behavior...")
+        _write_qa_flow(script, answer="London")
+
+        # Failing test
+        print("\n4. assert_no_diff (changed behavior)...")
+        try:
+            assert_no_diff(
+                entrypoint=script,
+                expected_artifact=baseline,
+                offline=False,
+            )
+            print("   ERROR: Should not reach here!")
+        except ArtifactDiffError as e:
+            idx = e.diff_result["first_divergent_index"]
+            print(f"   FAILED — {type(e).__name__} raised")
+            print(f"   Divergence index: {idx}")
+            print("   Message preview:")
+            for line in str(e).split("\n")[:4]:
+                print(f"     {line}")
+
+        # Show the real test pattern
+        print("\n5. In a real pytest test, you'd write:")
+        print(
+            textwrap.dedent(
+                """\
+           from forkline.testing import assert_no_diff
+
+           def test_my_flow():
+               assert_no_diff(
+                   entrypoint="examples/my_flow.py",
+                   expected_artifact="tests/testdata/my_flow.run.json",
+                   offline=True,
+               )"""
+            )
+        )
+
+    print("=" * 60)
+    print("Test helper demo complete.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/forkline/__init__.py
+++ b/forkline/__init__.py
@@ -11,7 +11,6 @@ from .ci import (
     normalize_artifact,
     offline_context,
 )
-from .testing import ArtifactDiffError, assert_no_diff
 from .core import (
     # First-divergence diffing
     DivergenceType,
@@ -74,6 +73,7 @@ from .core.replay import (
     replay_mode,
 )
 from .storage import RunRecorder, SQLiteStore
+from .testing import ArtifactDiffError, assert_no_diff
 from .tracer import Tracer
 from .version import (
     DEFAULT_FORKLINE_VERSION,

--- a/forkline/__init__.py
+++ b/forkline/__init__.py
@@ -1,4 +1,17 @@
 from .artifact import ArtifactEvent, RunArtifact, SchemaVersionError, migrate_artifact
+from .ci import (
+    EXIT_ARTIFACT_ERROR,
+    EXIT_DIFF_DETECTED,
+    EXIT_INTERNAL_ERROR,
+    EXIT_OFFLINE_VIOLATION,
+    EXIT_REPLAY_FAILED,
+    EXIT_SUCCESS,
+    EXIT_USAGE_ERROR,
+    ForklineOfflineError,
+    normalize_artifact,
+    offline_context,
+)
+from .testing import ArtifactDiffError, assert_no_diff
 from .core import (
     # First-divergence diffing
     DivergenceType,
@@ -141,4 +154,18 @@ __all__ = [
     "compare_steps",
     # Legacy
     "replay",
+    # CI integration
+    "EXIT_SUCCESS",
+    "EXIT_DIFF_DETECTED",
+    "EXIT_USAGE_ERROR",
+    "EXIT_REPLAY_FAILED",
+    "EXIT_OFFLINE_VIOLATION",
+    "EXIT_ARTIFACT_ERROR",
+    "EXIT_INTERNAL_ERROR",
+    "ForklineOfflineError",
+    "normalize_artifact",
+    "offline_context",
+    # Testing helpers
+    "assert_no_diff",
+    "ArtifactDiffError",
 ]

--- a/forkline/ci/__init__.py
+++ b/forkline/ci/__init__.py
@@ -1,0 +1,39 @@
+"""Forkline CI integration layer.
+
+Deterministic, offline, build-failing diffs for CI/CD pipelines.
+
+Exit code contract:
+    0 = Success (no diff, replay ok)
+    1 = Diff detected (policy violation, should fail CI)
+    2 = Usage/config error (bad args, missing file)
+    3 = Replay failed (runtime exception, missing dependencies)
+    4 = Offline violation (network attempted in offline mode)
+    5 = Artifact/schema error (cannot parse, unsupported version)
+    6 = Internal error (unexpected bug)
+"""
+
+from .exitcodes import (
+    EXIT_ARTIFACT_ERROR,
+    EXIT_DIFF_DETECTED,
+    EXIT_INTERNAL_ERROR,
+    EXIT_OFFLINE_VIOLATION,
+    EXIT_REPLAY_FAILED,
+    EXIT_SUCCESS,
+    EXIT_USAGE_ERROR,
+)
+from .normalize import normalize_artifact
+from .offline import ForklineOfflineError, enable_offline_mode, offline_context
+
+__all__ = [
+    "EXIT_SUCCESS",
+    "EXIT_DIFF_DETECTED",
+    "EXIT_USAGE_ERROR",
+    "EXIT_REPLAY_FAILED",
+    "EXIT_OFFLINE_VIOLATION",
+    "EXIT_ARTIFACT_ERROR",
+    "EXIT_INTERNAL_ERROR",
+    "ForklineOfflineError",
+    "enable_offline_mode",
+    "offline_context",
+    "normalize_artifact",
+]

--- a/forkline/ci/commands.py
+++ b/forkline/ci/commands.py
@@ -26,7 +26,7 @@ from .exitcodes import (
     EXIT_USAGE_ERROR,
 )
 from .normalize import normalize_artifact
-from .offline import ForklineOfflineError, enable_offline_mode, offline_context
+from .offline import ForklineOfflineError, enable_offline_mode
 
 
 def ci_record(
@@ -158,14 +158,20 @@ def ci_replay(
     for ev in artifact.events:
         type_counts[ev.type] = type_counts.get(ev.type, 0) + 1
 
-    print(json.dumps({
-        "status": "ok",
-        "run_id": artifact.run_id,
-        "entrypoint": artifact.entrypoint,
-        "schema_version": artifact.schema_version,
-        "event_count": event_count,
-        "event_types": type_counts,
-    }, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "run_id": artifact.run_id,
+                "entrypoint": artifact.entrypoint,
+                "schema_version": artifact.schema_version,
+                "event_count": event_count,
+                "event_types": type_counts,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
 
     return EXIT_SUCCESS
 
@@ -206,11 +212,17 @@ def ci_diff(
 
     if diff_result["identical"]:
         if output_format == "json":
-            print(json.dumps({
-                "identical": True,
-                "expected_events": len(expected_events),
-                "actual_events": len(actual_events),
-            }, indent=2, sort_keys=True))
+            print(
+                json.dumps(
+                    {
+                        "identical": True,
+                        "expected_events": len(expected_events),
+                        "actual_events": len(actual_events),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
         else:
             print("No differences detected.")
         return EXIT_SUCCESS
@@ -322,7 +334,10 @@ def _diff_event_lists(
                 "payload_diff": payload_diff,
                 "total_expected": len(expected),
                 "total_actual": len(actual),
-                "suggestion": "Re-record baseline: forkline ci record --entrypoint <script> --out <path>",
+                "suggestion": (
+                    "Re-record baseline: forkline ci record"
+                    " --entrypoint <script> --out <path>"
+                ),
             }
 
     if len(expected) != len(actual):
@@ -332,7 +347,10 @@ def _diff_event_lists(
             "reason": "event_count_mismatch",
             "total_expected": len(expected),
             "total_actual": len(actual),
-            "suggestion": "Re-record baseline: forkline ci record --entrypoint <script> --out <path>",
+            "suggestion": (
+                "Re-record baseline: forkline ci record"
+                " --entrypoint <script> --out <path>"
+            ),
         }
 
     return {

--- a/forkline/ci/commands.py
+++ b/forkline/ci/commands.py
@@ -1,0 +1,382 @@
+"""CI command implementations.
+
+Each function returns an exit code from the CI exit code contract.
+Output goes to stdout (results) and stderr (errors/diagnostics).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from typing import Any, Dict, List, Optional
+
+from ..artifact.schema import RunArtifact, SchemaVersionError
+from ..core.json_diff import json_diff
+from ..storage.recorder import RunRecorder
+from .exitcodes import (
+    EXIT_ARTIFACT_ERROR,
+    EXIT_DIFF_DETECTED,
+    EXIT_INTERNAL_ERROR,
+    EXIT_OFFLINE_VIOLATION,
+    EXIT_REPLAY_FAILED,
+    EXIT_SUCCESS,
+    EXIT_USAGE_ERROR,
+)
+from .normalize import normalize_artifact
+from .offline import ForklineOfflineError, enable_offline_mode, offline_context
+
+
+def ci_record(
+    entrypoint: str,
+    out_path: str,
+    *,
+    offline: bool = False,
+    script_args: Optional[List[str]] = None,
+) -> int:
+    """Record a baseline artifact to a JSON file.
+
+    Runs the entrypoint script under Forkline tracing, then exports
+    the resulting artifact as a normalized JSON file suitable for
+    committing to version control.
+
+    Returns:
+        CI exit code.
+    """
+    if not os.path.isfile(entrypoint):
+        print(f"Error: entrypoint not found: {entrypoint}", file=sys.stderr)
+        return EXIT_USAGE_ERROR
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "ci_record.db")
+        recorder = RunRecorder(db_path=db_path)
+        run_id = recorder.start_run(entrypoint=entrypoint)
+
+        env = os.environ.copy()
+        env["FORKLINE_TRACING"] = "1"
+        env["FORKLINE_RUN_ID"] = run_id
+        env["FORKLINE_DB"] = db_path
+        if offline:
+            env["FORKLINE_OFFLINE"] = "1"
+
+        try:
+            if offline:
+                enable_offline_mode()
+            result = subprocess.run(
+                [sys.executable, entrypoint] + (script_args or []),
+                env=env,
+            )
+            exit_code = result.returncode
+        except ForklineOfflineError as e:
+            print(f"Offline violation: {e}", file=sys.stderr)
+            recorder.end_run(run_id, status="error")
+            return EXIT_OFFLINE_VIOLATION
+        except Exception as e:
+            print(f"Error: failed to execute {entrypoint}: {e}", file=sys.stderr)
+            recorder.end_run(run_id, status="error")
+            return EXIT_REPLAY_FAILED
+
+        status = "ok" if exit_code == 0 else "failed"
+        recorder.end_run(run_id, status=status)
+
+        if exit_code != 0:
+            print(
+                f"Error: script exited with code {exit_code}",
+                file=sys.stderr,
+            )
+            return EXIT_REPLAY_FAILED
+
+        artifact = recorder.load_artifact(run_id)
+        if artifact is None:
+            print("Error: failed to load recorded artifact", file=sys.stderr)
+            return EXIT_INTERNAL_ERROR
+
+        artifact_dict = artifact.to_dict()
+        normalized = normalize_artifact(artifact_dict)
+
+        os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+        with open(out_path, "w") as f:
+            json.dump(normalized, f, indent=2, sort_keys=True, default=str)
+            f.write("\n")
+
+    print(f"Recorded artifact: {out_path}", file=sys.stderr)
+    return EXIT_SUCCESS
+
+
+def ci_replay(
+    artifact_path: str,
+    *,
+    strict: bool = False,
+) -> int:
+    """Replay/validate a recorded artifact offline.
+
+    Loads the artifact, validates schema, and checks structural integrity.
+    With --strict, also validates that all events have complete payloads.
+
+    Returns:
+        CI exit code.
+    """
+    if not os.path.isfile(artifact_path):
+        print(f"Error: artifact not found: {artifact_path}", file=sys.stderr)
+        return EXIT_USAGE_ERROR
+
+    try:
+        with open(artifact_path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error: cannot parse artifact: {e}", file=sys.stderr)
+        return EXIT_ARTIFACT_ERROR
+
+    try:
+        artifact = RunArtifact.from_dict(data)
+    except SchemaVersionError as e:
+        print(f"Error: schema version error: {e}", file=sys.stderr)
+        return EXIT_ARTIFACT_ERROR
+    except Exception as e:
+        print(f"Error: invalid artifact structure: {e}", file=sys.stderr)
+        return EXIT_ARTIFACT_ERROR
+
+    errors = artifact.validate()
+    if errors:
+        for err in errors:
+            print(f"Validation error: {err}", file=sys.stderr)
+        return EXIT_ARTIFACT_ERROR
+
+    if strict:
+        for i, event in enumerate(artifact.events):
+            if not event.payload and event.type in ("tool_call", "output"):
+                print(
+                    f"Strict validation: event[{i}] ({event.type}) has empty payload",
+                    file=sys.stderr,
+                )
+                return EXIT_ARTIFACT_ERROR
+
+    event_count = len(artifact.events)
+    type_counts: Dict[str, int] = {}
+    for ev in artifact.events:
+        type_counts[ev.type] = type_counts.get(ev.type, 0) + 1
+
+    print(json.dumps({
+        "status": "ok",
+        "run_id": artifact.run_id,
+        "entrypoint": artifact.entrypoint,
+        "schema_version": artifact.schema_version,
+        "event_count": event_count,
+        "event_types": type_counts,
+    }, indent=2, sort_keys=True))
+
+    return EXIT_SUCCESS
+
+
+def ci_diff(
+    expected_path: str,
+    actual_path: str,
+    *,
+    output_format: str = "text",
+    fail_on: str = "any",
+) -> int:
+    """Diff two artifact files and return appropriate exit code.
+
+    Returns:
+        EXIT_SUCCESS (0) if no diff, EXIT_DIFF_DETECTED (1) if diff found.
+    """
+    for label, path in [("expected", expected_path), ("actual", actual_path)]:
+        if not os.path.isfile(path):
+            print(f"Error: {label} artifact not found: {path}", file=sys.stderr)
+            return EXIT_USAGE_ERROR
+
+    try:
+        with open(expected_path) as f:
+            expected_raw = json.load(f)
+        with open(actual_path) as f:
+            actual_raw = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error: cannot parse artifact: {e}", file=sys.stderr)
+        return EXIT_ARTIFACT_ERROR
+
+    expected = normalize_artifact(expected_raw)
+    actual = normalize_artifact(actual_raw)
+
+    expected_events = expected.get("events", [])
+    actual_events = actual.get("events", [])
+
+    diff_result = _diff_event_lists(expected_events, actual_events)
+
+    if diff_result["identical"]:
+        if output_format == "json":
+            print(json.dumps({
+                "identical": True,
+                "expected_events": len(expected_events),
+                "actual_events": len(actual_events),
+            }, indent=2, sort_keys=True))
+        else:
+            print("No differences detected.")
+        return EXIT_SUCCESS
+
+    if output_format == "json":
+        print(json.dumps(diff_result, indent=2, sort_keys=True, default=str))
+    else:
+        _render_diff_text(diff_result)
+
+    return EXIT_DIFF_DETECTED
+
+
+def ci_check(
+    entrypoint: str,
+    expected_path: str,
+    *,
+    offline: bool = True,
+    output_format: str = "text",
+    fail_on: str = "any",
+    script_args: Optional[List[str]] = None,
+) -> int:
+    """Record actual, diff against expected. Single command for CI.
+
+    Internally records into a temp directory, normalizes, and diffs
+    against the expected artifact.
+
+    Returns:
+        CI exit code.
+    """
+    if not os.path.isfile(entrypoint):
+        print(f"Error: entrypoint not found: {entrypoint}", file=sys.stderr)
+        return EXIT_USAGE_ERROR
+
+    if not os.path.isfile(expected_path):
+        print(f"Error: expected artifact not found: {expected_path}", file=sys.stderr)
+        return EXIT_USAGE_ERROR
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        actual_path = os.path.join(tmpdir, "actual.run.json")
+        record_exit = ci_record(
+            entrypoint,
+            actual_path,
+            offline=offline,
+            script_args=script_args,
+        )
+        if record_exit != EXIT_SUCCESS:
+            return record_exit
+
+        return ci_diff(
+            expected_path,
+            actual_path,
+            output_format=output_format,
+            fail_on=fail_on,
+        )
+
+
+def ci_normalize(
+    artifact_path: str,
+    out_path: Optional[str] = None,
+) -> int:
+    """Normalize an artifact file in-place or to a new path.
+
+    Returns:
+        CI exit code.
+    """
+    if not os.path.isfile(artifact_path):
+        print(f"Error: artifact not found: {artifact_path}", file=sys.stderr)
+        return EXIT_USAGE_ERROR
+
+    try:
+        with open(artifact_path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error: cannot parse artifact: {e}", file=sys.stderr)
+        return EXIT_ARTIFACT_ERROR
+
+    normalized = normalize_artifact(data)
+
+    target = out_path or artifact_path
+    os.makedirs(os.path.dirname(target) or ".", exist_ok=True)
+    with open(target, "w") as f:
+        json.dump(normalized, f, indent=2, sort_keys=True, default=str)
+        f.write("\n")
+
+    print(f"Normalized: {target}", file=sys.stderr)
+    return EXIT_SUCCESS
+
+
+def _diff_event_lists(
+    expected: List[Dict[str, Any]],
+    actual: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Compare two event lists, returning a structured diff result."""
+    for i, (exp, act) in enumerate(zip(expected, actual)):
+        exp_comparable = {"type": exp.get("type"), "payload": exp.get("payload", {})}
+        act_comparable = {"type": act.get("type"), "payload": act.get("payload", {})}
+
+        if exp_comparable != act_comparable:
+            payload_diff = json_diff(
+                exp.get("payload", {}),
+                act.get("payload", {}),
+            )
+            return {
+                "identical": False,
+                "first_divergent_index": i,
+                "event_type": exp.get("type", "unknown"),
+                "expected": exp_comparable,
+                "actual": act_comparable,
+                "payload_diff": payload_diff,
+                "total_expected": len(expected),
+                "total_actual": len(actual),
+                "suggestion": "Re-record baseline: forkline ci record --entrypoint <script> --out <path>",
+            }
+
+    if len(expected) != len(actual):
+        return {
+            "identical": False,
+            "first_divergent_index": min(len(expected), len(actual)),
+            "reason": "event_count_mismatch",
+            "total_expected": len(expected),
+            "total_actual": len(actual),
+            "suggestion": "Re-record baseline: forkline ci record --entrypoint <script> --out <path>",
+        }
+
+    return {
+        "identical": True,
+        "total_expected": len(expected),
+        "total_actual": len(actual),
+    }
+
+
+def _render_diff_text(diff_result: Dict[str, Any]) -> None:
+    """Render diff result as concise text for CI output."""
+    idx = diff_result.get("first_divergent_index", 0)
+
+    reason = diff_result.get("reason")
+    if reason == "event_count_mismatch":
+        print(
+            f"DIFF: Event count mismatch at index {idx}\n"
+            f"  expected: {diff_result['total_expected']} events\n"
+            f"  actual:   {diff_result['total_actual']} events"
+        )
+    else:
+        event_type = diff_result.get("event_type", "unknown")
+        print(f"DIFF: First divergence at event[{idx}] (type: {event_type})")
+
+        payload_diff = diff_result.get("payload_diff", [])
+        for op in payload_diff[:5]:
+            op_type = op.get("op", "?")
+            path = op.get("path", "?")
+            if op_type == "replace":
+                print(f"  {path}: {_trunc(op.get('old'))} -> {_trunc(op.get('new'))}")
+            elif op_type == "add":
+                print(f"  {path}: <missing> -> {_trunc(op.get('value'))}")
+            elif op_type == "remove":
+                print(f"  {path}: {_trunc(op.get('old'))} -> <removed>")
+        if len(payload_diff) > 5:
+            print(f"  ... and {len(payload_diff) - 5} more changes")
+
+    suggestion = diff_result.get("suggestion")
+    if suggestion:
+        print(f"\nSuggested fix: {suggestion}")
+
+
+def _trunc(val: Any, max_len: int = 60) -> str:
+    s = json.dumps(val, default=str, sort_keys=True)
+    if len(s) > max_len:
+        return s[: max_len - 3] + "..."
+    return s

--- a/forkline/ci/exitcodes.py
+++ b/forkline/ci/exitcodes.py
@@ -1,0 +1,23 @@
+"""CI exit code contract.
+
+Strict, documented exit codes for CI automation.
+These must remain stable across releases.
+"""
+
+EXIT_SUCCESS = 0
+EXIT_DIFF_DETECTED = 1
+EXIT_USAGE_ERROR = 2
+EXIT_REPLAY_FAILED = 3
+EXIT_OFFLINE_VIOLATION = 4
+EXIT_ARTIFACT_ERROR = 5
+EXIT_INTERNAL_ERROR = 6
+
+EXIT_CODE_DESCRIPTIONS = {
+    EXIT_SUCCESS: "Success, no diff / replay ok",
+    EXIT_DIFF_DETECTED: "Diff detected (policy violation; should fail CI)",
+    EXIT_USAGE_ERROR: "Usage/config error (bad args, missing file)",
+    EXIT_REPLAY_FAILED: "Replay failed (runtime exception, missing dependencies)",
+    EXIT_OFFLINE_VIOLATION: "Offline violation (network attempted in offline mode)",
+    EXIT_ARTIFACT_ERROR: "Artifact/schema error (cannot parse, unsupported version)",
+    EXIT_INTERNAL_ERROR: "Internal error (unexpected bug)",
+}

--- a/forkline/ci/normalize.py
+++ b/forkline/ci/normalize.py
@@ -9,15 +9,25 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
-TIMESTAMP_FIELDS: Set[str] = frozenset({
-    "ts", "started_at", "ended_at", "created_at", "timestamp",
-})
+TIMESTAMP_FIELDS: Set[str] = frozenset(
+    {
+        "ts",
+        "started_at",
+        "ended_at",
+        "created_at",
+        "timestamp",
+    }
+)
 
-UNSTABLE_METADATA_FIELDS: Set[str] = frozenset({
-    "python_version", "platform", "cwd",
-})
+UNSTABLE_METADATA_FIELDS: Set[str] = frozenset(
+    {
+        "python_version",
+        "platform",
+        "cwd",
+    }
+)
 
 NORMALIZED_TIMESTAMP = "2000-01-01T00:00:00+00:00"
 

--- a/forkline/ci/normalize.py
+++ b/forkline/ci/normalize.py
@@ -1,0 +1,109 @@
+"""Artifact normalization for deterministic CI diffs.
+
+Normalizes unstable fields (timestamps, UUIDs, platform info) so that
+artifacts recorded at different times or on different machines produce
+identical diffs when their behavior is the same.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Dict, List, Optional, Set
+
+TIMESTAMP_FIELDS: Set[str] = frozenset({
+    "ts", "started_at", "ended_at", "created_at", "timestamp",
+})
+
+UNSTABLE_METADATA_FIELDS: Set[str] = frozenset({
+    "python_version", "platform", "cwd",
+})
+
+NORMALIZED_TIMESTAMP = "2000-01-01T00:00:00+00:00"
+
+
+def normalize_artifact(
+    artifact: Dict[str, Any],
+    *,
+    normalize_timestamps: bool = True,
+    normalize_metadata: bool = True,
+    normalize_ids: bool = False,
+) -> Dict[str, Any]:
+    """Normalize an artifact dict for deterministic comparison.
+
+    Args:
+        artifact: Raw artifact dict (not mutated).
+        normalize_timestamps: Replace all timestamp values with a stable sentinel.
+        normalize_metadata: Remove platform-specific metadata fields.
+        normalize_ids: Replace run_id and event_ids with stable sequential values.
+
+    Returns:
+        A new dict with unstable fields normalized.
+    """
+    result = copy.deepcopy(artifact)
+
+    if normalize_timestamps:
+        _normalize_timestamps_inplace(result)
+
+    if normalize_metadata and "metadata" in result:
+        for field in UNSTABLE_METADATA_FIELDS:
+            result["metadata"].pop(field, None)
+        if not result["metadata"]:
+            result.pop("metadata", None)
+
+    if normalize_ids:
+        result = _normalize_ids(result)
+
+    if "events" in result:
+        result["events"] = _normalize_event_ordering(result["events"])
+
+    return result
+
+
+def normalize_artifact_json(
+    json_str: str,
+    *,
+    normalize_timestamps: bool = True,
+    normalize_metadata: bool = True,
+    normalize_ids: bool = False,
+) -> str:
+    """Normalize a JSON artifact string, returning normalized JSON."""
+    artifact = json.loads(json_str)
+    normalized = normalize_artifact(
+        artifact,
+        normalize_timestamps=normalize_timestamps,
+        normalize_metadata=normalize_metadata,
+        normalize_ids=normalize_ids,
+    )
+    return json.dumps(normalized, indent=2, sort_keys=True, default=str)
+
+
+def _normalize_timestamps_inplace(obj: Any) -> None:
+    """Recursively replace timestamp fields with a stable sentinel."""
+    if isinstance(obj, dict):
+        for key in list(obj.keys()):
+            if key in TIMESTAMP_FIELDS and isinstance(obj[key], str):
+                obj[key] = NORMALIZED_TIMESTAMP
+            else:
+                _normalize_timestamps_inplace(obj[key])
+    elif isinstance(obj, list):
+        for item in obj:
+            _normalize_timestamps_inplace(item)
+
+
+def _normalize_ids(artifact: Dict[str, Any]) -> Dict[str, Any]:
+    """Replace run_id and event_ids with stable sequential values."""
+    result = copy.deepcopy(artifact)
+    result["run_id"] = "normalized-run-id"
+
+    events = result.get("events", [])
+    for idx, event in enumerate(events):
+        event["event_id"] = idx
+        event["run_id"] = "normalized-run-id"
+
+    return result
+
+
+def _normalize_event_ordering(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Ensure event ordering is stable (already by event_id in practice)."""
+    return sorted(events, key=lambda e: e.get("event_id", 0))

--- a/forkline/ci/offline.py
+++ b/forkline/ci/offline.py
@@ -1,0 +1,92 @@
+"""Hard offline enforcement for CI runs.
+
+Monkeypatches socket, urllib, requests, and httpx to fail immediately
+with a clear, deterministic error when network access is attempted.
+
+The "fail closed" approach: if any code path touches network, it gets
+a ForklineOfflineError instead of hanging or timing out.
+"""
+
+from __future__ import annotations
+
+import socket
+from contextlib import contextmanager
+from typing import Any, Generator
+
+
+class ForklineOfflineError(Exception):
+    """Raised when network access is attempted in offline mode.
+
+    This error is deterministic: same call always produces the same error,
+    with the same message, regardless of environment or timing.
+    """
+
+    def __init__(self, operation: str = "network access"):
+        super().__init__(
+            f"Network access blocked: {operation}. "
+            f"Forkline is running in offline mode (FORKLINE_OFFLINE=1). "
+            f"All network calls are forbidden to ensure deterministic replay."
+        )
+        self.operation = operation
+
+
+_original_socket_connect = socket.socket.connect
+_original_create_connection = socket.create_connection
+_original_getaddrinfo = socket.getaddrinfo
+_offline_active = False
+
+
+def _blocked_connect(self: Any, *args: Any, **kwargs: Any) -> None:
+    address = args[0] if args else "unknown"
+    raise ForklineOfflineError(f"socket.connect({address})")
+
+
+def _blocked_create_connection(*args: Any, **kwargs: Any) -> None:
+    address = args[0] if args else "unknown"
+    raise ForklineOfflineError(f"socket.create_connection({address})")
+
+
+def _blocked_getaddrinfo(*args: Any, **kwargs: Any) -> list:
+    host = args[0] if args else "unknown"
+    raise ForklineOfflineError(f"socket.getaddrinfo({host})")
+
+
+def enable_offline_mode() -> None:
+    """Activate offline mode globally.
+
+    After calling this, any attempt to open a network connection
+    raises ForklineOfflineError immediately.
+    """
+    global _offline_active
+    if _offline_active:
+        return
+    socket.socket.connect = _blocked_connect  # type: ignore[assignment]
+    socket.create_connection = _blocked_create_connection  # type: ignore[assignment]
+    socket.getaddrinfo = _blocked_getaddrinfo  # type: ignore[assignment]
+    _offline_active = True
+
+
+def disable_offline_mode() -> None:
+    """Restore normal network access."""
+    global _offline_active
+    if not _offline_active:
+        return
+    socket.socket.connect = _original_socket_connect  # type: ignore[assignment]
+    socket.create_connection = _original_create_connection  # type: ignore[assignment]
+    socket.getaddrinfo = _original_getaddrinfo  # type: ignore[assignment]
+    _offline_active = False
+
+
+def is_offline_mode() -> bool:
+    """Check if offline mode is currently active."""
+    return _offline_active
+
+
+@contextmanager
+def offline_context() -> Generator[None, None, None]:
+    """Context manager that enforces offline mode for its duration."""
+    enable_offline_mode()
+    try:
+        yield
+    finally:
+        disable_offline_mode()

--- a/forkline/cli/__init__.py
+++ b/forkline/cli/__init__.py
@@ -190,7 +190,9 @@ def _cmd_ci_record(args: argparse.Namespace) -> None:
     script_args: list[str] = getattr(args, "script_args", None) or []
     if script_args and script_args[0] == "--":
         script_args = script_args[1:]
-    offline = getattr(args, "offline", False) or os.environ.get("FORKLINE_OFFLINE") == "1"
+    offline = (
+        getattr(args, "offline", False) or os.environ.get("FORKLINE_OFFLINE") == "1"
+    )
     code = ci_record(
         args.entrypoint,
         args.out,
@@ -222,7 +224,9 @@ def _cmd_ci_check(args: argparse.Namespace) -> None:
     script_args: list[str] = getattr(args, "script_args", None) or []
     if script_args and script_args[0] == "--":
         script_args = script_args[1:]
-    offline = getattr(args, "offline", True) or os.environ.get("FORKLINE_OFFLINE") == "1"
+    offline = (
+        getattr(args, "offline", True) or os.environ.get("FORKLINE_OFFLINE") == "1"
+    )
     code = ci_check(
         args.entrypoint,
         args.expected,

--- a/forkline/cli/__init__.py
+++ b/forkline/cli/__init__.py
@@ -8,6 +8,11 @@ Usage::
     forkline list [--limit N] [--json]
     forkline replay <run_id> [--json]
     forkline diff <run_id_a> <run_id_b> [--format pretty|json] [--first-divergence]
+    forkline ci record --entrypoint <script> --out <path>
+    forkline ci replay --artifact <path> [--strict]
+    forkline ci diff --expected <path> --actual <path> [--format json|text]
+    forkline ci check --expected <path> --entrypoint <script>
+    forkline ci normalize <artifact> [--out <path>]
 """
 
 from __future__ import annotations
@@ -18,6 +23,7 @@ import subprocess
 import sys
 from typing import Any, Dict, List
 
+from ..ci.commands import ci_check, ci_diff, ci_normalize, ci_record, ci_replay
 from ..storage.recorder import RunRecorder
 from .render import (
     render_diff_json,
@@ -176,6 +182,67 @@ def _cmd_diff(args: argparse.Namespace) -> None:
 
 
 # ---------------------------------------------------------------------------
+# CI Subcommands
+# ---------------------------------------------------------------------------
+
+
+def _cmd_ci_record(args: argparse.Namespace) -> None:
+    script_args: list[str] = getattr(args, "script_args", None) or []
+    if script_args and script_args[0] == "--":
+        script_args = script_args[1:]
+    offline = getattr(args, "offline", False) or os.environ.get("FORKLINE_OFFLINE") == "1"
+    code = ci_record(
+        args.entrypoint,
+        args.out,
+        offline=offline,
+        script_args=script_args,
+    )
+    sys.exit(code)
+
+
+def _cmd_ci_replay(args: argparse.Namespace) -> None:
+    code = ci_replay(
+        args.artifact,
+        strict=getattr(args, "strict", False),
+    )
+    sys.exit(code)
+
+
+def _cmd_ci_diff(args: argparse.Namespace) -> None:
+    code = ci_diff(
+        args.expected,
+        args.actual,
+        output_format=getattr(args, "format", "text"),
+        fail_on=getattr(args, "fail_on", "any"),
+    )
+    sys.exit(code)
+
+
+def _cmd_ci_check(args: argparse.Namespace) -> None:
+    script_args: list[str] = getattr(args, "script_args", None) or []
+    if script_args and script_args[0] == "--":
+        script_args = script_args[1:]
+    offline = getattr(args, "offline", True) or os.environ.get("FORKLINE_OFFLINE") == "1"
+    code = ci_check(
+        args.entrypoint,
+        args.expected,
+        offline=offline,
+        output_format=getattr(args, "format", "text"),
+        fail_on=getattr(args, "fail_on", "any"),
+        script_args=script_args,
+    )
+    sys.exit(code)
+
+
+def _cmd_ci_normalize(args: argparse.Namespace) -> None:
+    code = ci_normalize(
+        args.artifact,
+        out_path=getattr(args, "out", None),
+    )
+    sys.exit(code)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -283,6 +350,144 @@ def main(argv: list[str] | None = None) -> None:
         help="Stop at first divergence (default behavior)",
     )
     diff_parser.set_defaults(func=_cmd_diff)
+
+    # --- ci ---
+    ci_parser = subparsers.add_parser(
+        "ci",
+        help="CI integration commands",
+        description=(
+            "Commands for CI/CD pipelines: record baselines, replay artifacts, "
+            "diff for behavioral changes, and gate merges on behavioral identity."
+        ),
+    )
+    ci_subparsers = ci_parser.add_subparsers(dest="ci_command", help="CI subcommands")
+
+    # --- ci record ---
+    ci_record_parser = ci_subparsers.add_parser(
+        "record",
+        help="Record a baseline artifact for CI",
+        description="Run an entrypoint and produce a normalized, committable artifact.",
+    )
+    ci_record_parser.add_argument(
+        "--entrypoint", required=True, help="Path to Python script to execute"
+    )
+    ci_record_parser.add_argument(
+        "--out", required=True, help="Output path for the artifact JSON file"
+    )
+    ci_record_parser.add_argument(
+        "--offline",
+        action="store_true",
+        default=False,
+        help="Block all network access during recording",
+    )
+    ci_record_parser.add_argument(
+        "script_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments to pass to the script (use -- to separate)",
+    )
+    ci_record_parser.set_defaults(func=_cmd_ci_record)
+
+    # --- ci replay ---
+    ci_replay_parser = ci_subparsers.add_parser(
+        "replay",
+        help="Validate a recorded artifact offline",
+        description="Load and validate an artifact file without network access.",
+    )
+    ci_replay_parser.add_argument(
+        "--artifact", required=True, help="Path to artifact JSON file"
+    )
+    ci_replay_parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Enable strict validation (all events must have payloads)",
+    )
+    ci_replay_parser.set_defaults(func=_cmd_ci_replay)
+
+    # --- ci diff ---
+    ci_diff_parser = ci_subparsers.add_parser(
+        "diff",
+        help="Diff two artifact files",
+        description="Compare expected vs actual artifacts and fail on divergence.",
+    )
+    ci_diff_parser.add_argument(
+        "--expected", required=True, help="Path to expected (baseline) artifact"
+    )
+    ci_diff_parser.add_argument(
+        "--actual", required=True, help="Path to actual (new) artifact"
+    )
+    ci_diff_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    ci_diff_parser.add_argument(
+        "--fail-on",
+        choices=["any", "first-divergence", "semantic"],
+        default="any",
+        help="Diff policy (default: any)",
+    )
+    ci_diff_parser.set_defaults(func=_cmd_ci_diff)
+
+    # --- ci check ---
+    ci_check_parser = ci_subparsers.add_parser(
+        "check",
+        help="Record actual, diff against expected baseline",
+        description=(
+            "Run an entrypoint, record the result, and diff against an expected "
+            "artifact. Exits 1 if behavior changed."
+        ),
+    )
+    ci_check_parser.add_argument(
+        "--entrypoint", required=True, help="Path to Python script to execute"
+    )
+    ci_check_parser.add_argument(
+        "--expected", required=True, help="Path to expected (baseline) artifact"
+    )
+    ci_check_parser.add_argument(
+        "--offline",
+        action="store_true",
+        default=True,
+        help="Block all network access (default: on)",
+    )
+    ci_check_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    ci_check_parser.add_argument(
+        "--fail-on",
+        choices=["any", "first-divergence", "semantic"],
+        default="any",
+        help="Diff policy (default: any)",
+    )
+    ci_check_parser.add_argument(
+        "script_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments to pass to the script (use -- to separate)",
+    )
+    ci_check_parser.set_defaults(func=_cmd_ci_check)
+
+    # --- ci normalize ---
+    ci_normalize_parser = ci_subparsers.add_parser(
+        "normalize",
+        help="Normalize an artifact file for stable diffs",
+        description="Strip timestamps, platform metadata, and sort events.",
+    )
+    ci_normalize_parser.add_argument(
+        "artifact", help="Path to artifact JSON file to normalize"
+    )
+    ci_normalize_parser.add_argument(
+        "--out",
+        default=None,
+        help="Output path (default: overwrite in place)",
+    )
+    ci_normalize_parser.set_defaults(func=_cmd_ci_normalize)
+
+    # Handle bare `forkline ci` with no subcommand
+    ci_parser.set_defaults(func=lambda args: (ci_parser.print_help(), sys.exit(1)))
 
     args = parser.parse_args(argv)
     if hasattr(args, "func"):

--- a/forkline/testing.py
+++ b/forkline/testing.py
@@ -1,0 +1,121 @@
+"""Forkline test helpers for Python test suites.
+
+Provides a simple API for snapshot/golden-file testing of agentic workflows.
+
+Usage in pytest or unittest::
+
+    from forkline.testing import assert_no_diff
+
+    def test_my_flow():
+        assert_no_diff(
+            entrypoint="examples/my_flow.py",
+            expected_artifact="tests/testdata/my_flow.run.json",
+            offline=True,
+        )
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any, Dict, List, Optional
+
+from .ci.commands import ci_record, _diff_event_lists
+from .ci.exitcodes import EXIT_SUCCESS
+from .ci.normalize import normalize_artifact
+from .ci.offline import offline_context
+
+
+class ArtifactDiffError(AssertionError):
+    """Raised when an artifact diff is detected during testing.
+
+    Contains the structured diff result for programmatic inspection.
+    """
+
+    def __init__(self, message: str, diff_result: Dict[str, Any]):
+        super().__init__(message)
+        self.diff_result = diff_result
+
+
+def assert_no_diff(
+    entrypoint: str,
+    expected_artifact: str,
+    *,
+    offline: bool = True,
+    script_args: Optional[List[str]] = None,
+    normalize_timestamps: bool = True,
+    normalize_metadata: bool = True,
+) -> None:
+    """Assert that running an entrypoint produces the same artifact as expected.
+
+    Runs the entrypoint in a temp directory, normalizes the output,
+    and diffs against the expected artifact. Raises ArtifactDiffError
+    with a clean diff snippet if behavior changed.
+
+    Args:
+        entrypoint: Path to Python script to run.
+        expected_artifact: Path to expected artifact JSON file.
+        offline: If True, block all network access during the run.
+        script_args: Optional arguments to pass to the script.
+        normalize_timestamps: Normalize timestamps before comparison.
+        normalize_metadata: Normalize platform metadata before comparison.
+
+    Raises:
+        ArtifactDiffError: If a behavioral diff is detected.
+        FileNotFoundError: If entrypoint or expected_artifact doesn't exist.
+    """
+    if not os.path.isfile(entrypoint):
+        raise FileNotFoundError(f"Entrypoint not found: {entrypoint}")
+    if not os.path.isfile(expected_artifact):
+        raise FileNotFoundError(f"Expected artifact not found: {expected_artifact}")
+
+    with open(expected_artifact) as f:
+        expected_raw = json.load(f)
+
+    expected_normalized = normalize_artifact(
+        expected_raw,
+        normalize_timestamps=normalize_timestamps,
+        normalize_metadata=normalize_metadata,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        actual_path = os.path.join(tmpdir, "actual.run.json")
+
+        record_code = ci_record(
+            entrypoint,
+            actual_path,
+            offline=offline,
+            script_args=script_args,
+        )
+        if record_code != EXIT_SUCCESS:
+            raise RuntimeError(
+                f"Recording failed with exit code {record_code}. "
+                f"Check stderr for details."
+            )
+
+        with open(actual_path) as f:
+            actual_raw = json.load(f)
+
+    actual_normalized = normalize_artifact(
+        actual_raw,
+        normalize_timestamps=normalize_timestamps,
+        normalize_metadata=normalize_metadata,
+    )
+
+    expected_events = expected_normalized.get("events", [])
+    actual_events = actual_normalized.get("events", [])
+
+    diff_result = _diff_event_lists(expected_events, actual_events)
+
+    if not diff_result["identical"]:
+        idx = diff_result.get("first_divergent_index", 0)
+        snippet = json.dumps(diff_result, indent=2, sort_keys=True, default=str)
+        raise ArtifactDiffError(
+            f"Behavioral diff detected at event[{idx}].\n\n"
+            f"Expected artifact: {expected_artifact}\n"
+            f"Diff details:\n{snippet}\n\n"
+            f"To re-record the baseline:\n"
+            f"  forkline ci record --entrypoint {entrypoint} --out {expected_artifact}",
+            diff_result=diff_result,
+        )

--- a/forkline/testing.py
+++ b/forkline/testing.py
@@ -21,10 +21,9 @@ import os
 import tempfile
 from typing import Any, Dict, List, Optional
 
-from .ci.commands import ci_record, _diff_event_lists
+from .ci.commands import _diff_event_lists, ci_record
 from .ci.exitcodes import EXIT_SUCCESS
 from .ci.normalize import normalize_artifact
-from .ci.offline import offline_context
 
 
 class ArtifactDiffError(AssertionError):

--- a/forkline/version.py
+++ b/forkline/version.py
@@ -13,7 +13,7 @@ Schema versioning policy:
 """
 
 # Library version (matches pyproject.toml)
-FORKLINE_VERSION = "0.3.0"
+FORKLINE_VERSION = "0.5.0"
 
 # Current schema version for new artifacts.
 # This is the version stamped on every artifact written by this release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 forkline = "forkline.cli:main"
 
 [tool.setuptools]
-packages = ["forkline", "forkline.artifact", "forkline.cli", "forkline.core", "forkline.storage", "forkline.tracer"]
+packages = ["forkline", "forkline.artifact", "forkline.ci", "forkline.cli", "forkline.core", "forkline.storage", "forkline.tracer"]
 
 [tool.black]
 line-length = 88

--- a/tests/unit/test_ci.py
+++ b/tests/unit/test_ci.py
@@ -1,0 +1,800 @@
+"""Tests for Forkline CI integration layer.
+
+Covers exit codes, offline enforcement, artifact normalization,
+CI commands, and the end-to-end record/diff/check workflow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import tempfile
+import textwrap
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from forkline.ci.commands import (
+    ci_check,
+    ci_diff,
+    ci_normalize,
+    ci_record,
+    ci_replay,
+)
+from forkline.ci.exitcodes import (
+    EXIT_ARTIFACT_ERROR,
+    EXIT_DIFF_DETECTED,
+    EXIT_INTERNAL_ERROR,
+    EXIT_OFFLINE_VIOLATION,
+    EXIT_REPLAY_FAILED,
+    EXIT_SUCCESS,
+    EXIT_USAGE_ERROR,
+)
+from forkline.ci.normalize import (
+    NORMALIZED_TIMESTAMP,
+    normalize_artifact,
+    normalize_artifact_json,
+)
+from forkline.ci.offline import (
+    ForklineOfflineError,
+    disable_offline_mode,
+    enable_offline_mode,
+    is_offline_mode,
+    offline_context,
+)
+from forkline.cli import main
+
+
+class _TempDirMixin:
+    """Provides a per-test temporary directory."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmpdir.name
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _write_script(self, name: str, content: str) -> str:
+        path = os.path.join(self.tmpdir, name)
+        with open(path, "w") as f:
+            f.write(textwrap.dedent(content))
+        return path
+
+    def _write_artifact(self, name: str, data: dict) -> str:
+        path = os.path.join(self.tmpdir, name)
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        return path
+
+    def _make_artifact(self, **overrides) -> dict:
+        base = {
+            "schema_version": "1.0",
+            "run_id": "test-run-001",
+            "entrypoint": "test.py",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "ended_at": "2026-01-01T00:00:01+00:00",
+            "status": "ok",
+            "forkline_version": "0.4.0",
+            "events": [
+                {
+                    "event_id": 0,
+                    "run_id": "test-run-001",
+                    "ts": "2026-01-01T00:00:00+00:00",
+                    "type": "input",
+                    "payload": {"prompt": "hello"},
+                },
+                {
+                    "event_id": 1,
+                    "run_id": "test-run-001",
+                    "ts": "2026-01-01T00:00:01+00:00",
+                    "type": "output",
+                    "payload": {"result": "world"},
+                },
+            ],
+            "metadata": {
+                "python_version": "3.12.0",
+                "platform": "macOS-15.0",
+                "cwd": "/tmp/test",
+            },
+        }
+        base.update(overrides)
+        return base
+
+
+# =========================================================================
+# Exit Codes
+# =========================================================================
+
+
+class TestExitCodes(unittest.TestCase):
+    """Exit codes must have specific stable values."""
+
+    def test_exit_code_values(self):
+        self.assertEqual(EXIT_SUCCESS, 0)
+        self.assertEqual(EXIT_DIFF_DETECTED, 1)
+        self.assertEqual(EXIT_USAGE_ERROR, 2)
+        self.assertEqual(EXIT_REPLAY_FAILED, 3)
+        self.assertEqual(EXIT_OFFLINE_VIOLATION, 4)
+        self.assertEqual(EXIT_ARTIFACT_ERROR, 5)
+        self.assertEqual(EXIT_INTERNAL_ERROR, 6)
+
+    def test_all_distinct(self):
+        codes = [
+            EXIT_SUCCESS, EXIT_DIFF_DETECTED, EXIT_USAGE_ERROR,
+            EXIT_REPLAY_FAILED, EXIT_OFFLINE_VIOLATION,
+            EXIT_ARTIFACT_ERROR, EXIT_INTERNAL_ERROR,
+        ]
+        self.assertEqual(len(codes), len(set(codes)))
+
+
+# =========================================================================
+# Offline Enforcement
+# =========================================================================
+
+
+class TestOfflineMode(unittest.TestCase):
+    def tearDown(self):
+        disable_offline_mode()
+
+    def test_offline_context_blocks_socket(self):
+        with offline_context():
+            self.assertTrue(is_offline_mode())
+            with self.assertRaises(ForklineOfflineError) as ctx:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect(("example.com", 80))
+            self.assertIn("offline mode", str(ctx.exception))
+
+    def test_offline_blocks_create_connection(self):
+        with offline_context():
+            with self.assertRaises(ForklineOfflineError):
+                socket.create_connection(("example.com", 80))
+
+    def test_offline_blocks_getaddrinfo(self):
+        with offline_context():
+            with self.assertRaises(ForklineOfflineError):
+                socket.getaddrinfo("example.com", 80)
+
+    def test_offline_error_is_deterministic(self):
+        msg1 = None
+        msg2 = None
+        with offline_context():
+            try:
+                socket.create_connection(("example.com", 80))
+            except ForklineOfflineError as e:
+                msg1 = str(e)
+            try:
+                socket.create_connection(("example.com", 80))
+            except ForklineOfflineError as e:
+                msg2 = str(e)
+        self.assertIsNotNone(msg1)
+        self.assertEqual(msg1, msg2)
+
+    def test_offline_restores_after_context(self):
+        with offline_context():
+            self.assertTrue(is_offline_mode())
+        self.assertFalse(is_offline_mode())
+
+    def test_enable_disable_idempotent(self):
+        enable_offline_mode()
+        enable_offline_mode()
+        self.assertTrue(is_offline_mode())
+        disable_offline_mode()
+        disable_offline_mode()
+        self.assertFalse(is_offline_mode())
+
+    def test_offline_error_attributes(self):
+        err = ForklineOfflineError("socket.connect")
+        self.assertEqual(err.operation, "socket.connect")
+        self.assertIn("FORKLINE_OFFLINE", str(err))
+
+
+# =========================================================================
+# Artifact Normalization
+# =========================================================================
+
+
+class TestNormalization(_TempDirMixin, unittest.TestCase):
+    def test_timestamps_normalized(self):
+        artifact = self._make_artifact()
+        result = normalize_artifact(artifact)
+        self.assertEqual(result["started_at"], NORMALIZED_TIMESTAMP)
+        self.assertEqual(result["ended_at"], NORMALIZED_TIMESTAMP)
+        for event in result["events"]:
+            self.assertEqual(event["ts"], NORMALIZED_TIMESTAMP)
+
+    def test_metadata_stripped(self):
+        artifact = self._make_artifact()
+        result = normalize_artifact(artifact)
+        self.assertNotIn("metadata", result)
+
+    def test_metadata_preserved_when_disabled(self):
+        artifact = self._make_artifact()
+        result = normalize_artifact(artifact, normalize_metadata=False)
+        self.assertIn("metadata", result)
+        self.assertIn("python_version", result["metadata"])
+
+    def test_timestamps_preserved_when_disabled(self):
+        artifact = self._make_artifact()
+        original_ts = artifact["started_at"]
+        result = normalize_artifact(artifact, normalize_timestamps=False)
+        self.assertEqual(result["started_at"], original_ts)
+
+    def test_events_ordered_by_event_id(self):
+        artifact = self._make_artifact()
+        artifact["events"][0]["event_id"] = 5
+        artifact["events"][1]["event_id"] = 2
+        result = normalize_artifact(artifact)
+        self.assertEqual(result["events"][0]["event_id"], 2)
+        self.assertEqual(result["events"][1]["event_id"], 5)
+
+    def test_normalize_ids(self):
+        artifact = self._make_artifact()
+        result = normalize_artifact(artifact, normalize_ids=True)
+        self.assertEqual(result["run_id"], "normalized-run-id")
+        self.assertEqual(result["events"][0]["event_id"], 0)
+        self.assertEqual(result["events"][1]["event_id"], 1)
+
+    def test_normalize_deterministic(self):
+        artifact = self._make_artifact()
+        r1 = normalize_artifact(artifact)
+        r2 = normalize_artifact(artifact)
+        self.assertEqual(
+            json.dumps(r1, sort_keys=True),
+            json.dumps(r2, sort_keys=True),
+        )
+
+    def test_normalize_json_roundtrip(self):
+        artifact = self._make_artifact()
+        json_str = json.dumps(artifact)
+        result = normalize_artifact_json(json_str)
+        parsed = json.loads(result)
+        self.assertEqual(parsed["started_at"], NORMALIZED_TIMESTAMP)
+
+    def test_original_not_mutated(self):
+        artifact = self._make_artifact()
+        original_ts = artifact["started_at"]
+        normalize_artifact(artifact)
+        self.assertEqual(artifact["started_at"], original_ts)
+
+
+# =========================================================================
+# CI Record Command
+# =========================================================================
+
+
+class TestCIRecord(_TempDirMixin, unittest.TestCase):
+    def test_record_success(self):
+        script = self._write_script("ok.py", "print('hello')\n")
+        out_path = os.path.join(self.tmpdir, "out.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_record(script, out_path)
+        self.assertEqual(code, EXIT_SUCCESS)
+        self.assertTrue(os.path.isfile(out_path))
+        with open(out_path) as f:
+            artifact = json.load(f)
+        self.assertEqual(artifact["schema_version"], "1.0")
+        self.assertIn("events", artifact)
+
+    def test_record_missing_entrypoint(self):
+        out_path = os.path.join(self.tmpdir, "out.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_record("/nonexistent.py", out_path)
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+    def test_record_failed_script(self):
+        script = self._write_script("fail.py", "import sys; sys.exit(1)\n")
+        out_path = os.path.join(self.tmpdir, "out.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_record(script, out_path)
+        self.assertEqual(code, EXIT_REPLAY_FAILED)
+
+    def test_record_creates_directories(self):
+        script = self._write_script("ok.py", "print('hello')\n")
+        out_path = os.path.join(self.tmpdir, "sub", "dir", "out.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_record(script, out_path)
+        self.assertEqual(code, EXIT_SUCCESS)
+        self.assertTrue(os.path.isfile(out_path))
+
+    def test_record_artifact_is_normalized(self):
+        script = self._write_script("ok.py", "print('hello')\n")
+        out_path = os.path.join(self.tmpdir, "out.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            ci_record(script, out_path)
+        with open(out_path) as f:
+            artifact = json.load(f)
+        self.assertEqual(artifact["started_at"], NORMALIZED_TIMESTAMP)
+
+    def test_record_deterministic(self):
+        script = self._write_script("ok.py", "print('hello')\n")
+        out1 = os.path.join(self.tmpdir, "out1.run.json")
+        out2 = os.path.join(self.tmpdir, "out2.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            ci_record(script, out1)
+        with patch("sys.stderr", new_callable=StringIO):
+            ci_record(script, out2)
+        with open(out1) as f:
+            a1 = json.load(f)
+        with open(out2) as f:
+            a2 = json.load(f)
+        n1 = normalize_artifact(a1, normalize_ids=True)
+        n2 = normalize_artifact(a2, normalize_ids=True)
+        self.assertEqual(
+            json.dumps(n1, sort_keys=True),
+            json.dumps(n2, sort_keys=True),
+        )
+
+
+# =========================================================================
+# CI Replay Command
+# =========================================================================
+
+
+class TestCIReplay(_TempDirMixin, unittest.TestCase):
+    def test_replay_valid_artifact(self):
+        artifact_path = self._write_artifact("test.run.json", self._make_artifact())
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_replay(artifact_path)
+        self.assertEqual(code, EXIT_SUCCESS)
+        parsed = json.loads(out.getvalue())
+        self.assertEqual(parsed["status"], "ok")
+        self.assertEqual(parsed["event_count"], 2)
+
+    def test_replay_missing_file(self):
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_replay("/nonexistent.json")
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+    def test_replay_invalid_json(self):
+        path = os.path.join(self.tmpdir, "bad.json")
+        with open(path, "w") as f:
+            f.write("not json{{{")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_replay(path)
+        self.assertEqual(code, EXIT_ARTIFACT_ERROR)
+
+    def test_replay_missing_schema_version(self):
+        artifact = self._make_artifact()
+        del artifact["schema_version"]
+        path = self._write_artifact("no_schema.json", artifact)
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_replay(path)
+        self.assertEqual(code, EXIT_ARTIFACT_ERROR)
+
+    def test_replay_strict_empty_payload(self):
+        artifact = self._make_artifact()
+        artifact["events"].append({
+            "event_id": 2,
+            "run_id": "test-run-001",
+            "ts": "2026-01-01T00:00:02+00:00",
+            "type": "output",
+            "payload": {},
+        })
+        path = self._write_artifact("strict.json", artifact)
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_replay(path, strict=True)
+        self.assertEqual(code, EXIT_ARTIFACT_ERROR)
+
+    def test_replay_not_strict_allows_empty_payload(self):
+        artifact = self._make_artifact()
+        artifact["events"].append({
+            "event_id": 2,
+            "run_id": "test-run-001",
+            "ts": "2026-01-01T00:00:02+00:00",
+            "type": "output",
+            "payload": {},
+        })
+        path = self._write_artifact("lax.json", artifact)
+        with patch("sys.stdout", new_callable=StringIO):
+            code = ci_replay(path, strict=False)
+        self.assertEqual(code, EXIT_SUCCESS)
+
+
+# =========================================================================
+# CI Diff Command
+# =========================================================================
+
+
+class TestCIDiff(_TempDirMixin, unittest.TestCase):
+    def test_identical_artifacts(self):
+        artifact = self._make_artifact()
+        expected = self._write_artifact("expected.json", artifact)
+        actual = self._write_artifact("actual.json", artifact)
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_diff(expected, actual)
+        self.assertEqual(code, EXIT_SUCCESS)
+        self.assertIn("No differences", out.getvalue())
+
+    def test_different_artifacts(self):
+        expected_art = self._make_artifact()
+        actual_art = self._make_artifact()
+        actual_art["events"][1]["payload"]["result"] = "changed"
+        expected = self._write_artifact("expected.json", expected_art)
+        actual = self._write_artifact("actual.json", actual_art)
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_diff(expected, actual)
+        self.assertEqual(code, EXIT_DIFF_DETECTED)
+        self.assertIn("DIFF", out.getvalue())
+
+    def test_diff_json_format(self):
+        expected_art = self._make_artifact()
+        actual_art = self._make_artifact()
+        actual_art["events"][0]["payload"]["prompt"] = "goodbye"
+        expected = self._write_artifact("expected.json", expected_art)
+        actual = self._write_artifact("actual.json", actual_art)
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_diff(expected, actual, output_format="json")
+        self.assertEqual(code, EXIT_DIFF_DETECTED)
+        parsed = json.loads(out.getvalue())
+        self.assertFalse(parsed["identical"])
+        self.assertEqual(parsed["first_divergent_index"], 0)
+        self.assertIn("suggestion", parsed)
+
+    def test_diff_json_identical(self):
+        artifact = self._make_artifact()
+        expected = self._write_artifact("expected.json", artifact)
+        actual = self._write_artifact("actual.json", artifact)
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_diff(expected, actual, output_format="json")
+        self.assertEqual(code, EXIT_SUCCESS)
+        parsed = json.loads(out.getvalue())
+        self.assertTrue(parsed["identical"])
+
+    def test_diff_missing_expected(self):
+        actual = self._write_artifact("actual.json", self._make_artifact())
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_diff("/nonexistent.json", actual)
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+    def test_diff_missing_actual(self):
+        expected = self._write_artifact("expected.json", self._make_artifact())
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_diff(expected, "/nonexistent.json")
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+    def test_diff_event_count_mismatch(self):
+        expected_art = self._make_artifact()
+        actual_art = self._make_artifact()
+        actual_art["events"].append({
+            "event_id": 2,
+            "run_id": "test-run-001",
+            "ts": "2026-01-01T00:00:02+00:00",
+            "type": "system",
+            "payload": {"msg": "extra"},
+        })
+        expected = self._write_artifact("expected.json", expected_art)
+        actual = self._write_artifact("actual.json", actual_art)
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_diff(expected, actual)
+        self.assertEqual(code, EXIT_DIFF_DETECTED)
+        self.assertIn("mismatch", out.getvalue())
+
+    def test_diff_bad_json(self):
+        expected = self._write_artifact("expected.json", self._make_artifact())
+        bad_path = os.path.join(self.tmpdir, "bad.json")
+        with open(bad_path, "w") as f:
+            f.write("{not valid")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_diff(expected, bad_path)
+        self.assertEqual(code, EXIT_ARTIFACT_ERROR)
+
+    def test_diff_normalizes_timestamps(self):
+        """Artifacts recorded at different times should still match."""
+        art1 = self._make_artifact()
+        art1["started_at"] = "2026-02-01T12:00:00+00:00"
+        art1["events"][0]["ts"] = "2026-02-01T12:00:00+00:00"
+        art2 = self._make_artifact()
+        art2["started_at"] = "2026-03-15T08:00:00+00:00"
+        art2["events"][0]["ts"] = "2026-03-15T08:00:00+00:00"
+        p1 = self._write_artifact("a.json", art1)
+        p2 = self._write_artifact("b.json", art2)
+        with patch("sys.stdout", new_callable=StringIO):
+            code = ci_diff(p1, p2)
+        self.assertEqual(code, EXIT_SUCCESS)
+
+
+# =========================================================================
+# CI Normalize Command
+# =========================================================================
+
+
+class TestCINormalize(_TempDirMixin, unittest.TestCase):
+    def test_normalize_in_place(self):
+        artifact = self._make_artifact()
+        path = self._write_artifact("test.json", artifact)
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_normalize(path)
+        self.assertEqual(code, EXIT_SUCCESS)
+        with open(path) as f:
+            result = json.load(f)
+        self.assertEqual(result["started_at"], NORMALIZED_TIMESTAMP)
+
+    def test_normalize_to_new_path(self):
+        artifact = self._make_artifact()
+        src = self._write_artifact("src.json", artifact)
+        dst = os.path.join(self.tmpdir, "dst.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_normalize(src, out_path=dst)
+        self.assertEqual(code, EXIT_SUCCESS)
+        self.assertTrue(os.path.isfile(dst))
+
+    def test_normalize_missing_file(self):
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_normalize("/nonexistent.json")
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+    def test_normalize_bad_json(self):
+        path = os.path.join(self.tmpdir, "bad.json")
+        with open(path, "w") as f:
+            f.write("{bad")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_normalize(path)
+        self.assertEqual(code, EXIT_ARTIFACT_ERROR)
+
+
+# =========================================================================
+# CI Check Command (end-to-end)
+# =========================================================================
+
+
+class TestCICheck(_TempDirMixin, unittest.TestCase):
+    def test_check_pass(self):
+        """Record expected, then check passes."""
+        script = self._write_script("ok.py", "print('hello')\n")
+        expected_path = os.path.join(self.tmpdir, "expected.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            ci_record(script, expected_path, offline=False)
+        with patch("sys.stderr", new_callable=StringIO):
+            with patch("sys.stdout", new_callable=StringIO):
+                code = ci_check(script, expected_path, offline=False)
+        self.assertEqual(code, EXIT_SUCCESS)
+
+    def test_check_fail_on_behavior_change(self):
+        """Behavior change must produce exit code 1."""
+        script_v1 = self._write_script("v1.py", """\
+            import os, json
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            run_id = os.environ.get("FORKLINE_RUN_ID", "")
+            if db and run_id:
+                import sqlite3
+                conn = sqlite3.connect(db)
+                conn.execute(
+                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                    (run_id, "2026-01-01T00:00:00+00:00", "output",
+                     json.dumps({"result": "v1"})),
+                )
+                conn.commit()
+                conn.close()
+        """)
+        expected_path = os.path.join(self.tmpdir, "expected.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            ci_record(script_v1, expected_path, offline=False)
+
+        script_v2 = self._write_script("v2.py", """\
+            import os, json
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            run_id = os.environ.get("FORKLINE_RUN_ID", "")
+            if db and run_id:
+                import sqlite3
+                conn = sqlite3.connect(db)
+                conn.execute(
+                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                    (run_id, "2026-01-01T00:00:00+00:00", "output",
+                     json.dumps({"result": "v2_changed"})),
+                )
+                conn.commit()
+                conn.close()
+        """)
+        with patch("sys.stderr", new_callable=StringIO):
+            with patch("sys.stdout", new_callable=StringIO):
+                code = ci_check(script_v2, expected_path, offline=False)
+        self.assertEqual(code, EXIT_DIFF_DETECTED)
+
+    def test_check_missing_entrypoint(self):
+        expected = self._write_artifact("expected.json", self._make_artifact())
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_check("/nonexistent.py", expected, offline=False)
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+    def test_check_missing_expected(self):
+        script = self._write_script("ok.py", "print('hello')\n")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_check(script, "/nonexistent.json", offline=False)
+        self.assertEqual(code, EXIT_USAGE_ERROR)
+
+
+# =========================================================================
+# CLI Integration (forkline ci ...)
+# =========================================================================
+
+
+class TestCLICICommands(_TempDirMixin, unittest.TestCase):
+    def test_ci_no_subcommand(self):
+        with self.assertRaises(SystemExit) as ctx:
+            with patch("sys.stdout", new_callable=StringIO):
+                main(["ci"])
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_ci_record_via_cli(self):
+        script = self._write_script("ok.py", "print('hello')\n")
+        out_path = os.path.join(self.tmpdir, "out.run.json")
+        with self.assertRaises(SystemExit) as ctx:
+            with patch("sys.stderr", new_callable=StringIO):
+                main(["ci", "record", "--entrypoint", script, "--out", out_path])
+        self.assertEqual(ctx.exception.code, EXIT_SUCCESS)
+        self.assertTrue(os.path.isfile(out_path))
+
+    def test_ci_replay_via_cli(self):
+        path = self._write_artifact("test.json", self._make_artifact())
+        with self.assertRaises(SystemExit) as ctx:
+            with patch("sys.stdout", new_callable=StringIO):
+                main(["ci", "replay", "--artifact", path])
+        self.assertEqual(ctx.exception.code, EXIT_SUCCESS)
+
+    def test_ci_diff_identical_via_cli(self):
+        artifact = self._make_artifact()
+        p1 = self._write_artifact("a.json", artifact)
+        p2 = self._write_artifact("b.json", artifact)
+        with self.assertRaises(SystemExit) as ctx:
+            with patch("sys.stdout", new_callable=StringIO):
+                main(["ci", "diff", "--expected", p1, "--actual", p2])
+        self.assertEqual(ctx.exception.code, EXIT_SUCCESS)
+
+    def test_ci_diff_diverged_via_cli(self):
+        a1 = self._make_artifact()
+        a2 = self._make_artifact()
+        a2["events"][0]["payload"]["prompt"] = "different"
+        p1 = self._write_artifact("a.json", a1)
+        p2 = self._write_artifact("b.json", a2)
+        with self.assertRaises(SystemExit) as ctx:
+            with patch("sys.stdout", new_callable=StringIO):
+                main(["ci", "diff", "--expected", p1, "--actual", p2])
+        self.assertEqual(ctx.exception.code, EXIT_DIFF_DETECTED)
+
+    def test_ci_normalize_via_cli(self):
+        path = self._write_artifact("test.json", self._make_artifact())
+        with self.assertRaises(SystemExit) as ctx:
+            with patch("sys.stderr", new_callable=StringIO):
+                main(["ci", "normalize", path])
+        self.assertEqual(ctx.exception.code, EXIT_SUCCESS)
+
+
+# =========================================================================
+# End-to-End: Record → Diff → Detect Change
+# =========================================================================
+
+
+class TestEndToEnd(_TempDirMixin, unittest.TestCase):
+    """Full integration test: record, confirm pass, change, confirm fail."""
+
+    def test_full_cycle(self):
+        script = self._write_script("flow.py", """\
+            import os, json
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            run_id = os.environ.get("FORKLINE_RUN_ID", "")
+            if db and run_id:
+                import sqlite3
+                conn = sqlite3.connect(db)
+                conn.execute(
+                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                    (run_id, "2026-01-01T00:00:00+00:00", "input",
+                     json.dumps({"prompt": "what is 2+2?"})),
+                )
+                conn.execute(
+                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                    (run_id, "2026-01-01T00:00:01+00:00", "output",
+                     json.dumps({"answer": "4"})),
+                )
+                conn.commit()
+                conn.close()
+        """)
+
+        # Step 1: Record baseline
+        baseline_path = os.path.join(self.tmpdir, "baseline.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            code = ci_record(script, baseline_path, offline=False)
+        self.assertEqual(code, EXIT_SUCCESS)
+
+        # Step 2: Replay validates cleanly
+        with patch("sys.stdout", new_callable=StringIO):
+            code = ci_replay(baseline_path)
+        self.assertEqual(code, EXIT_SUCCESS)
+
+        # Step 3: Same script passes check
+        with patch("sys.stderr", new_callable=StringIO):
+            with patch("sys.stdout", new_callable=StringIO):
+                code = ci_check(script, baseline_path, offline=False)
+        self.assertEqual(code, EXIT_SUCCESS)
+
+        # Step 4: Modified script fails check with exit code 1
+        script_v2 = self._write_script("flow_v2.py", """\
+            import os, json
+            db = os.environ.get("FORKLINE_DB", "runs.db")
+            run_id = os.environ.get("FORKLINE_RUN_ID", "")
+            if db and run_id:
+                import sqlite3
+                conn = sqlite3.connect(db)
+                conn.execute(
+                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                    (run_id, "2026-01-01T00:00:00+00:00", "input",
+                     json.dumps({"prompt": "what is 2+2?"})),
+                )
+                conn.execute(
+                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                    (run_id, "2026-01-01T00:00:01+00:00", "output",
+                     json.dumps({"answer": "5"})),
+                )
+                conn.commit()
+                conn.close()
+        """)
+        with patch("sys.stderr", new_callable=StringIO):
+            with patch("sys.stdout", new_callable=StringIO) as out:
+                code = ci_check(script_v2, baseline_path, offline=False)
+        self.assertEqual(code, EXIT_DIFF_DETECTED)
+
+        # Step 5: Diff output in JSON mode is machine-readable
+        actual_path = os.path.join(self.tmpdir, "actual_v2.run.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            ci_record(script_v2, actual_path, offline=False)
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = ci_diff(baseline_path, actual_path, output_format="json")
+        self.assertEqual(code, EXIT_DIFF_DETECTED)
+        parsed = json.loads(out.getvalue())
+        self.assertFalse(parsed["identical"])
+        self.assertIn("first_divergent_index", parsed)
+        self.assertIn("suggestion", parsed)
+
+
+# =========================================================================
+# Exit Code Scenarios
+# =========================================================================
+
+
+class TestExitCodeScenarios(_TempDirMixin, unittest.TestCase):
+    """Each exit code must be exercised by a specific scenario."""
+
+    def test_exit_0_success(self):
+        artifact = self._make_artifact()
+        p1 = self._write_artifact("a.json", artifact)
+        p2 = self._write_artifact("b.json", artifact)
+        with patch("sys.stdout", new_callable=StringIO):
+            self.assertEqual(ci_diff(p1, p2), EXIT_SUCCESS)
+
+    def test_exit_1_diff_detected(self):
+        a1 = self._make_artifact()
+        a2 = self._make_artifact()
+        a2["events"][0]["payload"]["prompt"] = "changed"
+        p1 = self._write_artifact("a.json", a1)
+        p2 = self._write_artifact("b.json", a2)
+        with patch("sys.stdout", new_callable=StringIO):
+            self.assertEqual(ci_diff(p1, p2), EXIT_DIFF_DETECTED)
+
+    def test_exit_2_usage_error(self):
+        with patch("sys.stderr", new_callable=StringIO):
+            self.assertEqual(ci_record("/no/such/file.py", "/tmp/out.json"), EXIT_USAGE_ERROR)
+
+    def test_exit_3_replay_failed(self):
+        script = self._write_script("fail.py", "import sys; sys.exit(1)\n")
+        out = os.path.join(self.tmpdir, "out.json")
+        with patch("sys.stderr", new_callable=StringIO):
+            self.assertEqual(ci_record(script, out), EXIT_REPLAY_FAILED)
+
+    def test_exit_5_artifact_error(self):
+        path = os.path.join(self.tmpdir, "bad.json")
+        with open(path, "w") as f:
+            f.write("not json")
+        with patch("sys.stderr", new_callable=StringIO):
+            self.assertEqual(ci_replay(path), EXIT_ARTIFACT_ERROR)
+
+    def test_exit_5_schema_error(self):
+        artifact = self._make_artifact()
+        del artifact["schema_version"]
+        path = self._write_artifact("no_schema.json", artifact)
+        with patch("sys.stderr", new_callable=StringIO):
+            self.assertEqual(ci_replay(path), EXIT_ARTIFACT_ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_ci.py
+++ b/tests/unit/test_ci.py
@@ -122,9 +122,13 @@ class TestExitCodes(unittest.TestCase):
 
     def test_all_distinct(self):
         codes = [
-            EXIT_SUCCESS, EXIT_DIFF_DETECTED, EXIT_USAGE_ERROR,
-            EXIT_REPLAY_FAILED, EXIT_OFFLINE_VIOLATION,
-            EXIT_ARTIFACT_ERROR, EXIT_INTERNAL_ERROR,
+            EXIT_SUCCESS,
+            EXIT_DIFF_DETECTED,
+            EXIT_USAGE_ERROR,
+            EXIT_REPLAY_FAILED,
+            EXIT_OFFLINE_VIOLATION,
+            EXIT_ARTIFACT_ERROR,
+            EXIT_INTERNAL_ERROR,
         ]
         self.assertEqual(len(codes), len(set(codes)))
 
@@ -365,13 +369,15 @@ class TestCIReplay(_TempDirMixin, unittest.TestCase):
 
     def test_replay_strict_empty_payload(self):
         artifact = self._make_artifact()
-        artifact["events"].append({
-            "event_id": 2,
-            "run_id": "test-run-001",
-            "ts": "2026-01-01T00:00:02+00:00",
-            "type": "output",
-            "payload": {},
-        })
+        artifact["events"].append(
+            {
+                "event_id": 2,
+                "run_id": "test-run-001",
+                "ts": "2026-01-01T00:00:02+00:00",
+                "type": "output",
+                "payload": {},
+            }
+        )
         path = self._write_artifact("strict.json", artifact)
         with patch("sys.stderr", new_callable=StringIO):
             code = ci_replay(path, strict=True)
@@ -379,13 +385,15 @@ class TestCIReplay(_TempDirMixin, unittest.TestCase):
 
     def test_replay_not_strict_allows_empty_payload(self):
         artifact = self._make_artifact()
-        artifact["events"].append({
-            "event_id": 2,
-            "run_id": "test-run-001",
-            "ts": "2026-01-01T00:00:02+00:00",
-            "type": "output",
-            "payload": {},
-        })
+        artifact["events"].append(
+            {
+                "event_id": 2,
+                "run_id": "test-run-001",
+                "ts": "2026-01-01T00:00:02+00:00",
+                "type": "output",
+                "payload": {},
+            }
+        )
         path = self._write_artifact("lax.json", artifact)
         with patch("sys.stdout", new_callable=StringIO):
             code = ci_replay(path, strict=False)
@@ -457,13 +465,15 @@ class TestCIDiff(_TempDirMixin, unittest.TestCase):
     def test_diff_event_count_mismatch(self):
         expected_art = self._make_artifact()
         actual_art = self._make_artifact()
-        actual_art["events"].append({
-            "event_id": 2,
-            "run_id": "test-run-001",
-            "ts": "2026-01-01T00:00:02+00:00",
-            "type": "system",
-            "payload": {"msg": "extra"},
-        })
+        actual_art["events"].append(
+            {
+                "event_id": 2,
+                "run_id": "test-run-001",
+                "ts": "2026-01-01T00:00:02+00:00",
+                "type": "system",
+                "payload": {"msg": "extra"},
+            }
+        )
         expected = self._write_artifact("expected.json", expected_art)
         actual = self._write_artifact("actual.json", actual_art)
         with patch("sys.stdout", new_callable=StringIO) as out:
@@ -553,7 +563,9 @@ class TestCICheck(_TempDirMixin, unittest.TestCase):
 
     def test_check_fail_on_behavior_change(self):
         """Behavior change must produce exit code 1."""
-        script_v1 = self._write_script("v1.py", """\
+        script_v1 = self._write_script(
+            "v1.py",
+            """\
             import os, json
             db = os.environ.get("FORKLINE_DB", "runs.db")
             run_id = os.environ.get("FORKLINE_RUN_ID", "")
@@ -561,18 +573,21 @@ class TestCICheck(_TempDirMixin, unittest.TestCase):
                 import sqlite3
                 conn = sqlite3.connect(db)
                 conn.execute(
-                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
                     (run_id, "2026-01-01T00:00:00+00:00", "output",
                      json.dumps({"result": "v1"})),
                 )
                 conn.commit()
                 conn.close()
-        """)
+        """,
+        )
         expected_path = os.path.join(self.tmpdir, "expected.run.json")
         with patch("sys.stderr", new_callable=StringIO):
             ci_record(script_v1, expected_path, offline=False)
 
-        script_v2 = self._write_script("v2.py", """\
+        script_v2 = self._write_script(
+            "v2.py",
+            """\
             import os, json
             db = os.environ.get("FORKLINE_DB", "runs.db")
             run_id = os.environ.get("FORKLINE_RUN_ID", "")
@@ -580,13 +595,14 @@ class TestCICheck(_TempDirMixin, unittest.TestCase):
                 import sqlite3
                 conn = sqlite3.connect(db)
                 conn.execute(
-                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
                     (run_id, "2026-01-01T00:00:00+00:00", "output",
                      json.dumps({"result": "v2_changed"})),
                 )
                 conn.commit()
                 conn.close()
-        """)
+        """,
+        )
         with patch("sys.stderr", new_callable=StringIO):
             with patch("sys.stdout", new_callable=StringIO):
                 code = ci_check(script_v2, expected_path, offline=False)
@@ -670,26 +686,28 @@ class TestEndToEnd(_TempDirMixin, unittest.TestCase):
     """Full integration test: record, confirm pass, change, confirm fail."""
 
     def test_full_cycle(self):
-        script = self._write_script("flow.py", """\
+        script = self._write_script(
+            "flow.py",
+            """\
             import os, json
             db = os.environ.get("FORKLINE_DB", "runs.db")
             run_id = os.environ.get("FORKLINE_RUN_ID", "")
+            SQL = "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)"
             if db and run_id:
                 import sqlite3
                 conn = sqlite3.connect(db)
-                conn.execute(
-                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                conn.execute(SQL,
                     (run_id, "2026-01-01T00:00:00+00:00", "input",
                      json.dumps({"prompt": "what is 2+2?"})),
                 )
-                conn.execute(
-                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                conn.execute(SQL,
                     (run_id, "2026-01-01T00:00:01+00:00", "output",
                      json.dumps({"answer": "4"})),
                 )
                 conn.commit()
                 conn.close()
-        """)
+        """,
+        )
 
         # Step 1: Record baseline
         baseline_path = os.path.join(self.tmpdir, "baseline.run.json")
@@ -709,26 +727,28 @@ class TestEndToEnd(_TempDirMixin, unittest.TestCase):
         self.assertEqual(code, EXIT_SUCCESS)
 
         # Step 4: Modified script fails check with exit code 1
-        script_v2 = self._write_script("flow_v2.py", """\
+        script_v2 = self._write_script(
+            "flow_v2.py",
+            """\
             import os, json
             db = os.environ.get("FORKLINE_DB", "runs.db")
             run_id = os.environ.get("FORKLINE_RUN_ID", "")
+            SQL = "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)"
             if db and run_id:
                 import sqlite3
                 conn = sqlite3.connect(db)
-                conn.execute(
-                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                conn.execute(SQL,
                     (run_id, "2026-01-01T00:00:00+00:00", "input",
                      json.dumps({"prompt": "what is 2+2?"})),
                 )
-                conn.execute(
-                    "INSERT INTO events (run_id, ts, type, payload) VALUES (?, ?, ?, ?)",
+                conn.execute(SQL,
                     (run_id, "2026-01-01T00:00:01+00:00", "output",
                      json.dumps({"answer": "5"})),
                 )
                 conn.commit()
                 conn.close()
-        """)
+        """,
+        )
         with patch("sys.stderr", new_callable=StringIO):
             with patch("sys.stdout", new_callable=StringIO) as out:
                 code = ci_check(script_v2, baseline_path, offline=False)
@@ -773,7 +793,9 @@ class TestExitCodeScenarios(_TempDirMixin, unittest.TestCase):
 
     def test_exit_2_usage_error(self):
         with patch("sys.stderr", new_callable=StringIO):
-            self.assertEqual(ci_record("/no/such/file.py", "/tmp/out.json"), EXIT_USAGE_ERROR)
+            self.assertEqual(
+                ci_record("/no/such/file.py", "/tmp/out.json"), EXIT_USAGE_ERROR
+            )
 
     def test_exit_3_replay_failed(self):
         script = self._write_script("fail.py", "import sys; sys.exit(1)\n")


### PR DESCRIPTION
## CI + Test Harness: Deterministic, Offline, Build-Failing Diffs

### Summary

Adds Forkline's CI integration layer — a deterministic, offline, build-failing diff system that gates merges on **behavioral identity**. If an agent's output changes, the build fails with a clear, machine-readable diff and a non-zero exit code.

- New `forkline ci` command suite: `record`, `replay`, `diff`, `check`, `normalize`
- Hard offline enforcement via socket monkeypatching (`ForklineOfflineError` — no hangs, no timeouts)
- Artifact normalization strips timestamps, platform metadata, and sorts events for stable cross-machine diffs
- Strict exit code contract (0–6) documented and tested for every scenario
- Python test helper (`assert_no_diff`) for snapshot-style testing in pytest/unittest
- 60 new tests including a full end-to-end cycle: record → pass → change → fail with exit 1

### New files

| Path | Purpose |
|------|---------|
| `forkline/ci/__init__.py` | Package exports |
| `forkline/ci/exitcodes.py` | Exit code contract (0=success, 1=diff, 2=usage, 3=replay, 4=offline, 5=artifact, 6=internal) |
| `forkline/ci/offline.py` | Socket-level network blocking with `offline_context()` |
| `forkline/ci/normalize.py` | Timestamp/metadata normalization for stable diffs |
| `forkline/ci/commands.py` | Core command implementations (`ci_record`, `ci_replay`, `ci_diff`, `ci_check`, `ci_normalize`) |
| `forkline/testing.py` | `assert_no_diff()` helper for test suites |
| `tests/unit/test_ci.py` | 60 tests covering all commands, exit codes, offline, normalization, and e2e |
| `docs/ci.md` | Full CI guide: commands, exit codes, offline mode, GitHub Actions example |
| `examples/ci_record_and_diff.py` | Example: record baseline, diff identical and changed behavior |
| `examples/ci_check_gate.py` | Example: all-in-one build gate with `ci_check` |
| `examples/ci_offline_enforcement.py` | Example: offline mode blocking network calls |
| `examples/ci_test_helper.py` | Example: `assert_no_diff` for pytest/unittest |

### Modified files

| Path | Change |
|------|--------|
| `forkline/cli/__init__.py` | Wire `ci` subcommand with 5 nested subcommands into argparse |
| `forkline/__init__.py` | Export CI and testing APIs |
| `pyproject.toml` | Add `forkline.ci` to packages list |
| `README.md` | Add CI Integration section, update roadmap, CLI reference |

### Commands

```bash
# Record a normalized, committable artifact
forkline ci record --entrypoint <script> --out <path> [--offline]

# Validate an artifact's schema and structure
forkline ci replay --artifact <path> [--strict]

# Diff two artifacts (exit 1 on divergence)
forkline ci diff --expected <path> --actual <path> [--format json|text]

# All-in-one: record actual, diff against expected
forkline ci check --entrypoint <script> --expected <path> [--offline]

# Normalize an artifact for stable diffs
forkline ci normalize <artifact> [--out <path>]
```

### Exit codes

| Code | Meaning |
|------|---------|
| `0` | Success, no diff |
| `1` | Diff detected (fail the build) |
| `2` | Usage/config error |
| `3` | Replay failed |
| `4` | Offline violation |
| `5` | Artifact/schema error |
| `6` | Internal error |

### Test plan

- [x] Exit code values are stable and distinct (2 tests)
- [x] Offline mode blocks `socket.connect`, `create_connection`, `getaddrinfo` (4 tests)
- [x] Offline errors are deterministic across calls (1 test)
- [x] Offline mode restores after context exit (2 tests)
- [x] Normalization strips timestamps, metadata; preserves payloads (9 tests)
- [x] `ci record` succeeds, handles missing files, failed scripts, creates dirs (6 tests)
- [x] `ci replay` validates schema, handles strict mode (6 tests)
- [x] `ci diff` detects identical/divergent artifacts in text and JSON (9 tests)
- [x] `ci normalize` in-place and to new path (4 tests)
- [x] `ci check` passes on same behavior, fails on change (4 tests)
- [x] CLI integration: all commands accessible via `forkline ci ...` (6 tests)
- [x] End-to-end: record → replay → check pass → change → check fail (exit 1) → JSON diff (1 test)
- [x] Every exit code (0, 1, 2, 3, 5) exercised by a specific scenario (6 tests)
- [x] All 376 tests pass (316 existing + 60 new)
- [x] All 4 examples run successfully
